### PR TITLE
Fixed race condition with VSCode deployment

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -53,8 +53,9 @@ const initialSettings = api.getPreferences();
 let brsHomeMode = !initialSettings?.simulator?.options?.includes("disableHomeScreen");
 
 // Initialize variables
+const defaultAppInfo = { id: "", path: "", icon: "", running: false };
 let appList = structuredClone(customDeviceInfo.appList ?? []);
-let currentApp = { id: "", path: "", icon: "", running: false };
+let currentApp = structuredClone(defaultAppInfo);
 let launchAppId = "";
 let debugMode = "continue";
 let editor = null;
@@ -454,7 +455,7 @@ function appLoaded(appData) {
 }
 
 function appTerminated() {
-    currentApp = { id: "", running: false };
+    currentApp = structuredClone(defaultAppInfo);
     stats.style.visibility = "hidden";
     api.updateTitle(defaultTitle);
     api.enableMenuItem("close-channel", false);

--- a/src/helpers/events.js
+++ b/src/helpers/events.js
@@ -66,7 +66,9 @@ function installerEvents(event, data) {
     } else if (event === "install") {
         const input = new Map();
         input.set("source", data.source);
-        loadFile([data.file], input);
+        setTimeout(() => {
+            loadFile([data.file], input);
+        }, 500);
     }
 }
 


### PR DESCRIPTION
In some cases the `installer` service was deploying faster than the ECP service could process the `home` keys sent by the VSCode extension, so I added a timeout to not deploy until the keys are processed.