### PR TITLE
Prevent loading a package larger than 5MB

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -22,3 +22,6 @@ export const BRS_HOME_APP_PATH = "./assets/brs-home.zip";
 
 // Editor temporary file name
 export const EDITOR_CODE_BRS = "editor_code.brs";
+
+// Maximum package size in MB
+export const MAX_PACKAGE_SIZE_MB = 5;


### PR DESCRIPTION
Roku allows up to 4mb but for development purposes we may need a zip larger, but more than 5MB may cause issues to the simulator too.