### PR TITLE
In home app mode, only display closing app toast with `error` or `crash`

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -225,7 +225,7 @@ api.receive("setCaptionStyle", function (newStyles) {
 api.receive("executeFile", function (filePath, data, clear, mute, debug, input) {
     // Close the SceneGraph warning dialog if it's still open
     const dialog = document.getElementById("scenegraph-warning-dialog");
-    if (dialog && dialog.style.display === "flex") {
+    if (dialog?.style?.display === "flex") {
         dialog.style.display = "none";
     }
 


### PR DESCRIPTION
Prevented display a toast red message when changing Display Mode