### PR TITLE
feat: Add keepAppOpen setting for Peer Roku

### DIFF
--- a/src/helpers/roku.js
+++ b/src/helpers/roku.js
@@ -42,8 +42,10 @@ ipcMain.on("currentApp", (_, data) => {
             return;
         }
         if (isValidIP(device.ip)) {
-            postEcpRequest(device, "/exit-app/dev");
-            postEcpRequest(device, "/keypress/home");
+            if (!device.keepAppOpen) {
+                postEcpRequest(device, "/exit-app/dev");
+                postEcpRequest(device, "/keypress/home");
+            }
         }
     }
 });

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -858,6 +858,17 @@ export function getSettings(window) {
                                     ],
                                     help: "If enabled, the simulator will replicate all pressed control keys on the peer Roku device",
                                 },
+                                {
+                                    key: "keepAppOpen",
+                                    type: "checkbox",
+                                    options: [
+                                        {
+                                            label: "Do not close the app on Roku when Simulator exits",
+                                            value: "enabled",
+                                        },
+                                    ],
+                                    help: "If enabled, the app will continue running on the peer Roku device after the simulator finishes",
+                                },
                             ],
                         },
                     ],
@@ -1286,6 +1297,7 @@ export function getPeerRoku() {
         username: DEFAULT_USRPWD,
         password: settings.value("peerRoku.password"),
         syncControl: settings.value("peerRoku.syncControl")?.includes("enabled") || false,
+        keepAppOpen: settings.value("peerRoku.keepAppOpen")?.includes("enabled") || false,
     };
 }
 


### PR DESCRIPTION
Adds a setting to allow the user to keep the app running on the peer Roku device even when the simulator exits.
Closes #232 