### PR TITLE
feat: adjust update check intervals and add skip version option

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -28,5 +28,5 @@ export const EDITOR_CODE_BRS = "editor_code.brs";
 export const MAX_PACKAGE_SIZE_MB = 7;
 
 // Update check intervals (in milliseconds)
-export const UPDATE_CHECK_STARTUP = 10000; // 30 seconds
-export const UPDATE_CHECK_INTERVAL = 4 * 60 * 60 * 1000; // 4 hours
+export const UPDATE_CHECK_STARTUP = 15000; // 15 seconds
+export const UPDATE_CHECK_INTERVAL = 24 * 60 * 60 * 1000; // 24 hours

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -60,6 +60,7 @@ export function getSettings(window) {
             simulator: {
                 options: ["statusBar", "debugOnCrash"],
                 theme: "purple",
+                skippedUpdateVersion: "",
             },
             services: {
                 installer: isLinux ? [] : ["enabled"],

--- a/src/helpers/updates.js
+++ b/src/helpers/updates.js
@@ -8,6 +8,7 @@
 import { app, dialog, BrowserWindow, shell } from "electron";
 import https from "node:https";
 import packageInfo from "../../package.json";
+import { getSettings } from "./settings";
 
 let updateAvailable = false;
 let latestVersion = null;
@@ -46,7 +47,7 @@ function showUpdateAvailableDialog(version) {
             title: "Update Available",
             message: `A new version (${version}) is available!`,
             detail: "Click 'Download' to visit the releases page and download the latest version.",
-            buttons: ["Download", "Later"],
+            buttons: ["Download", "Later", "Skip this Version"],
             defaultId: 0,
         })
         .then((result) => {
@@ -54,6 +55,10 @@ function showUpdateAvailableDialog(version) {
                 // User chose to download - open releases page
                 const repoUrl = packageInfo.repository.url.replace(/\.git$/, "");
                 shell.openExternal(`${repoUrl}/releases/latest`);
+            } else if (result.response === 2) {
+                // User chose to skip this version
+                const settings = getSettings(mainWindow);
+                settings?.value("simulator.skippedUpdateVersion", version);
             }
             // Reset flag when dialog is dismissed
             dialogShown = false;
@@ -79,7 +84,24 @@ function showNoUpdatesDialog(version) {
 
 // Handle version comparison result
 function handleVersionCheck(currentVersion, forceCheck, resolve) {
+    const mainWindow = BrowserWindow.fromId(1);
+    let skippedVersion = "";
+    if (mainWindow) {
+        const settings = getSettings(mainWindow);
+        skippedVersion = settings?.value("simulator.skippedUpdateVersion");
+        if (!app.isPackaged && skippedVersion) {
+            console.log(`Skipped version: ${skippedVersion}`);
+        }
+    }
+
     if (compareVersions(currentVersion, latestVersion) === 1) {
+        if (!forceCheck && skippedVersion === latestVersion) {
+            // Silently ignore skipped version if not manually forced
+            updateAvailable = false;
+            resolve({ updateAvailable: false, version: currentVersion });
+            return;
+        }
+
         updateAvailable = true;
         if (!app.isPackaged) {
             console.log(`Update available: ${latestVersion}`);

--- a/src/main.js
+++ b/src/main.js
@@ -251,7 +251,7 @@ app.on("ready", () => {
     subscribeServerEvents();
     // Initialize version checking (only in production and if not disabled)
     if (app.isPackaged && !getSimulatorOption("disableCheckForUpdates")) {
-        // Check for updates 30 seconds after app start
+        // Check for updates 15 seconds after app start
         setTimeout(async () => {
             try {
                 await checkForUpdates();
@@ -260,7 +260,7 @@ app.on("ready", () => {
             }
         }, UPDATE_CHECK_STARTUP);
 
-        // Check for updates every 4 hours
+        // Check for updates every 24 hours
         setInterval(async () => {
             try {
                 await checkForUpdates();


### PR DESCRIPTION
Adjusted the initial update check to 15 seconds and recurring checks to 24 hours. Added a feature to skip a specific version from being prompted.