### PR TITLE
feat: add clipboard paste support for sending text to the simulator via sequential keypresses

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -314,6 +314,48 @@ api.receive("copyScreenshot", function () {
 api.receive("saveScreenshot", function (file) {
     takeScreenshot(file);
 });
+// Paste Text Handler - sends each character as a sequential Lit_ keypress
+let pasteQueue = [];
+let isPasting = false;
+function processPasteQueue() {
+    if (pasteQueue.length === 0) {
+        isPasting = false;
+        return;
+    }
+    isPasting = true;
+    const key = pasteQueue.shift();
+    brs.sendKeyPress(key);
+    setTimeout(processPasteQueue, 100);
+}
+let lastPasteTime = 0;
+api.receive("pasteText", function (text) {
+    if (!currentApp.running) {
+        return;
+    }
+    // Debounce to prevent double-paste from menu accelerator + capture handler
+    const now = Date.now();
+    if (now - lastPasteTime < 200) {
+        return;
+    }
+    lastPasteTime = now;
+    for (let i = 0; i < text.length; i++) {
+        const char = text[i];
+        if (char === "\r") {
+            pasteQueue.push("enter");
+            // Skip the following \n in a \r\n sequence
+            if (i + 1 < text.length && text[i + 1] === "\n") {
+                i++;
+            }
+        } else if (char === "\n") {
+            pasteQueue.push("enter");
+        } else {
+            pasteQueue.push(`Lit_${char}`);
+        }
+    }
+    if (!isPasting) {
+        processPasteQueue();
+    }
+});
 api.receive("setDisplay", function (mode) {
     if (mode !== brs.getDisplayMode()) {
         brs.setDisplayMode(mode);

--- a/src/app/preload.js
+++ b/src/app/preload.js
@@ -23,6 +23,21 @@ globalThis.addEventListener("DOMContentLoaded", () => {
         getCurrentWebContents().send("copyScreenshot");
         return false;
     });
+    // Intercept Cmd+V / Ctrl+V in capture phase to prevent "v" from reaching brs-engine
+    // Only apply in the main simulator window (which has the #display canvas)
+    if (document.getElementById("display")) {
+        document.addEventListener("keydown", function (e) {
+            if ((e.metaKey || e.ctrlKey) && e.key === "v") {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                const { clipboard } = require("electron");
+                const text = clipboard.readText();
+                if (text && text.length > 0) {
+                    getCurrentWebContents().send("pasteText", text);
+                }
+            }
+        }, true); // capture phase fires before brs-engine's bubbling-phase handler
+    }
 });
 
 contextBridge.exposeInMainWorld("api", {
@@ -149,6 +164,7 @@ contextBridge.exposeInMainWorld("api", {
             "serverStatus",
             "copyScreenshot",
             "saveScreenshot",
+            "pasteText",
             "executeFile",
             "openEditor",
             "editorUndo",

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -50,6 +50,9 @@ export function getSettings(window) {
     const bounds = window.getBounds();
     const x = Math.round(bounds.x + Math.abs(bounds.width - w) / 2);
     const y = Math.round(bounds.y + Math.abs(bounds.height - h + 25) / 2);
+    if (!app.isPackaged) {
+        console.log("Loading settings from:", path.resolve(app.getPath("userData"), "brs-settings.json"));
+    }
     settings = new ElectronPreferences({
         debug: false,
         config: {

--- a/src/menu/editMenuTemplate.js
+++ b/src/menu/editMenuTemplate.js
@@ -5,6 +5,7 @@
  *
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { clipboard, BrowserWindow } from "electron";
 import { showSettings } from "../helpers/settings";
 import { copyScreenshot } from "../helpers/window";
 const isMacOS = process.platform === "darwin";
@@ -26,7 +27,19 @@ export const editMenuTemplate = {
                 copyScreenshot();
             },
         },
-        { label: "Paste", accelerator: "CmdOrCtrl+V", selector: "paste:", visible: isMacOS },
+        {
+            label: "Paste",
+            accelerator: "CmdOrCtrl+V",
+            click: () => {
+                const window = BrowserWindow.fromId(1);
+                if (window) {
+                    const text = clipboard.readText();
+                    if (text && text.length > 0) {
+                        window.webContents.send("pasteText", text);
+                    }
+                }
+            },
+        },
         {
             label: "Select All",
             accelerator: "CmdOrCtrl+A",


### PR DESCRIPTION
Adds the ability to paste text from the clipboard into a running BrightScript app. Pasted text is decomposed into sequential `Lit_` keypress ECP commands, matching the same protocol used by the Roku ECP `/keypress/Lit_*` endpoints. This enables quick text entry into input fields in Roku channel apps without needing to type character-by-character using the keyboard.

## Motivation

When developing or testing Roku channels with text input fields (e.g., search boxes, login forms), typing text character-by-character through the remote keyboard is slow and tedious. Physical Roku devices support text entry via the Roku mobile app's keyboard, but the simulator had no equivalent. This change bridges that gap by allowing standard clipboard paste (`Cmd+V` / `Ctrl+V`) to inject text directly into the running app.

## How It Works

1. **Keyboard shortcut** (`Cmd+V` / `Ctrl+V`): A capture-phase `keydown` listener in the preload intercepts the paste shortcut before the brs-engine's keyboard handler can process the raw "v" key. It reads the clipboard text and sends it to the renderer via a new `pasteText` IPC channel.

2. **Edit menu → Paste**: The Edit menu's Paste item now uses a custom `click` handler (replacing the macOS native `paste:` selector) that reads the clipboard and sends the same `pasteText` IPC to the simulator.

3. **Sequential keypress queue** (renderer): Each character in the pasted text is converted to a `Lit_<char>` keypress and pushed into a queue. The queue is processed synchronously with a 100ms delay between each keypress to prevent garbling the text order. Newlines (`\n`, `\r`, `\r\n`) are mapped to the `enter` key.

## Changes

| File | Change |
|:-----|:-------|
| `src/app/preload.js` | Added capture-phase `keydown` listener for `Cmd+V`/`Ctrl+V` (scoped to main window only via `#display` element check). Whitelisted `pasteText` IPC channel. |
| `src/app/app.js` | Added `pasteText` handler with queue-based sequential keypress dispatch (100ms delay per character). Includes 200ms debounce to prevent double-paste. |
| `src/menu/editMenuTemplate.js` | Replaced native `selector: "paste:"` with custom `click` handler that reads clipboard and sends `pasteText` IPC. Paste is now visible on all platforms. |

## Design Decisions

- **Capture-phase event listener**: Uses `addEventListener(..., true)` to intercept `Cmd+V` before the brs-engine's bubbling-phase `keydown` handler processes the "v" as a literal keypress. This is essential to prevent a stray "v" from being injected before the pasted text.

- **Scoped to main window only**: The capture-phase listener checks for the `#display` canvas element, so it only activates in the main simulator window. The editor window (Monaco) retains native paste behavior.

- **Queue-based processing**: Follows the same pattern used by the debug server's `type` command (`processTypeQueue` in `debug.js`). A 100ms delay between keypresses ensures the brs-engine processes each character before receiving the next.

- **Debounce**: A 200ms debounce on the `pasteText` handler guards against the edge case where both the menu accelerator's click handler and the capture-phase DOM handler fire for the same keystroke.

## Testing

- Paste single characters, words, and multi-line text into a running app with a text input field
- Verify no extra "v" character appears before pasted text
- Verify Edit → Paste menu item works
- Verify native paste still works in the Code Editor window (Monaco)
- Verify paste is ignored when no app is running
