### PR TITLE
feat: add Customization Settings for Custom Features

### DIFF
--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -137,6 +137,9 @@ export function getSettings(window) {
                 sendInput: [],
                 inputMap: {},
             },
+            customization: {
+                customFeatures: [],
+            },
         },
         browserWindowOverrides: {
             title: "Settings",
@@ -963,6 +966,27 @@ export function getSettings(window) {
                     ],
                 },
             },
+            {
+                id: "customization",
+                label: "Customization",
+                icon: formatPath(path.join(__dirname, "/images/svg/coding.svg")),
+                form: {
+                    groups: [
+                        {
+                            label: "Custom Features",
+                            fields: [
+                                {
+                                    label: "Custom Features List",
+                                    key: "customFeatures",
+                                    type: "list",
+                                    addItemLabel: "Add Feature",
+                                    help: "Add custom features to be passed to the BrightScript app via roDeviceInfo.hasFeature() method.",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            },
         ],
     });
     updatePeerRokuFieldOptions();
@@ -1000,6 +1024,9 @@ export function getSettings(window) {
         }
         if (preferences.externalVolume) {
             handleExternalVolumeSettings(window, preferences.externalVolume);
+        }
+        if (preferences.customization) {
+            setDeviceInfo("customization", "customFeatures", true);
         }
     });
     nativeTheme.on("updated", () => {
@@ -1135,11 +1162,15 @@ export function setPreference(key, value) {
 export function setDeviceInfo(section, key, notifyApp) {
     const oldValue = globalThis.sharedObject.deviceInfo[key];
     const newValue = settings.value(`${section}.${key}`);
-    if (newValue && newValue !== oldValue) {
-        globalThis.sharedObject.deviceInfo[key] = newValue;
+    let isDifferent = newValue !== oldValue;
+    if (Array.isArray(newValue) && Array.isArray(oldValue)) {
+        isDifferent = JSON.stringify(newValue) !== JSON.stringify(oldValue);
+    }
+    if (newValue !== undefined && isDifferent) {
+        globalThis.sharedObject.deviceInfo[key] = Array.isArray(newValue) ? [...newValue] : newValue;
         if (notifyApp) {
             const window = BrowserWindow.fromId(1);
-            window?.webContents.send("setDeviceInfo", key, newValue);
+            window?.webContents.send("setDeviceInfo", key, Array.isArray(newValue) ? [...newValue] : newValue);
         }
     }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -92,6 +92,7 @@ const deviceInfo = {
     tmpVolSize: 100 * 1024 * 1024, // 100 MB
     cacheFSVolSize: 100 * 1024 * 1024, // 100 MB
     appList: getAppList(),
+    customFeatures: [],
 };
 
 // Get Network Gateway
@@ -335,6 +336,9 @@ function loadSettings(mainWindow, startup) {
         const peerRoku = getPeerRoku();
         checkMenuItem("peer-roku-deploy", peerRoku.deploy);
         checkMenuItem("peer-roku-control", peerRoku.syncControl);
+    }
+    if (settings.preferences.customization) {
+        setDeviceInfo("customization", "customFeatures");
     }
 }
 


### PR DESCRIPTION
This PR introduces a new "Customization" settings tab that allows developers to define custom features to be passed to the BrightScript app's `roDeviceInfo` component. This makes it possible to simulate environments with specific hardware or software capabilities (e.g., `touch_controls`) directly from the emulator settings.

## Changes
* **Settings UI**: Added a "Customization" tab using `@lvcabral/electron-preferences` containing a list field that lets users add/remove custom feature strings.
* **Device Info Updates**: Updated the underlying `deviceInfo` object in `main.js` to natively include the `customFeatures` array by default.
* **Settings Initialization**: Added logic to `loadSettings()` in `main.js` so that saved custom features are injected into the device data on simulator startup.
* **Robust Array Equality Checks**: Enhanced the `setDeviceInfo` IPC broadcast method in `settings.js` to correctly deep-compare arrays using `JSON.stringify()`. This ensures that in-place array mutations from the settings panel reliably trigger updates to the simulation engine. 
* **State Immutability**: Array values sent by the settings UI are now cloned before saving to the shared object (`[...newValue]`), preventing reference mutation issues on subsequent saves.

## Files Modified
* `src/main.js`
* `src/helpers/settings.js`
