### PR TITLE
feat: add video auto-play setting to device configuration and UI preferences

### DIFF
--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -79,6 +79,7 @@ export function getSettings(window) {
                 RIDA: globalThis.sharedObject.deviceInfo.RIDA,
                 developerId: globalThis.sharedObject.deviceInfo.developerId,
                 developerPwd: "",
+                autoPlayEnabled: globalThis.sharedObject.deviceInfo.autoPlayEnabled ? ["enabled"] : [],
             },
             display: {
                 displayMode: "720p",
@@ -418,13 +419,27 @@ export function getSettings(window) {
                                     label: "Developer Id",
                                     key: "developerId",
                                     type: "text",
+                                    style: { width: "45%" },
                                     help: "Unique id to segregate registry data, the registry only changes after a reset or app restart",
                                 },
                                 {
                                     label: "Developer Password",
                                     key: "developerPwd",
                                     type: "text",
+                                    style: { width: "45%" },
                                     help: "Password used to encrypt and decrypt the app package source code, needs to be 32 bytes long",
+                                },
+                                {
+                                    label: "Video Auto-Play",
+                                    key: "autoPlayEnabled",
+                                    type: "checkbox",
+                                    options: [
+                                        {
+                                            label: "Enabled",
+                                            value: "enabled",
+                                        },
+                                    ],
+                                    help: "Enables or disables Video Auto-Play setting returned by ifDeviceInfo.IsAutoPlayEnabled()",
                                 },
                             ],
                         },
@@ -997,6 +1012,11 @@ export function getSettings(window) {
         setDeviceInfo("device", "clientId", true);
         setDeviceInfo("device", "RIDA", true);
         setDeviceInfo("device", "developerId"); // Do not notify app to avoid change registry without reset
+        const autoPlay = preferences.device.autoPlayEnabled.includes("enabled");
+        if (globalThis.sharedObject.deviceInfo.autoPlayEnabled !== autoPlay) {
+            globalThis.sharedObject.deviceInfo.autoPlayEnabled = autoPlay;
+            window.webContents.send("setDeviceInfo", "autoPlayEnabled", autoPlay);
+        }
         saveDisplaySettings(window);
         setRemoteKeys(settings.defaults.remote, preferences.remote);
         if (preferences.audio) {

--- a/src/main.js
+++ b/src/main.js
@@ -66,6 +66,7 @@ const deviceInfo = {
     deviceModel: "4200X",
     clientId: randomUUID(), // Unique identifier of the device
     RIDA: randomUUID(), // Unique identifier for advertisement tracking
+    autoPlayEnabled: true,
     countryCode: "US",
     timeZone: dt.zoneName,
     timeZoneIANA: dt.zoneName,
@@ -86,6 +87,7 @@ const deviceInfo = {
     },
     localIps: localIps,
     startTime: Date.now(),
+    autoPlayEnabled: true,
     maxSimulStreams: 2,
     audioVolume: 50,
     audioLanguage: "en",
@@ -304,6 +306,10 @@ function loadSettings(mainWindow, startup) {
         setDeviceInfo("device", "clientId");
         setDeviceInfo("device", "RIDA");
         setDeviceInfo("device", "developerId");
+        const autoPlayEnabled = settings.value("device.autoPlayEnabled");
+        if (Array.isArray(autoPlayEnabled)) {
+            globalThis.sharedObject.deviceInfo.autoPlayEnabled = autoPlayEnabled.includes("enabled");
+        }
     }
     if (settings.preferences.display) {
         setDisplayOption("displayMode");


### PR DESCRIPTION
The video auto-play flag is now enabled in the simulation engine device info, and we needed to add an option for the user to change it.