### PR TITLE
feat: update installer `password` right away and clarify service restart only needed for `port`

### DIFF
--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -328,7 +328,7 @@ export function getSettings(window) {
                                             value: "enabled",
                                         },
                                     ],
-                                    help: "This service allows to remotely side load an app, to change port and password restart the service",
+                                    help: "This service allows to remotely side load an app, to make port change effective, restart the service",
                                 },
                                 {
                                     label: "Port (default: 80)",
@@ -1495,9 +1495,9 @@ function saveServicesSettings(services, window) {
         return;
     }
     if (services.installer?.includes("enabled")) {
+        setPassword(services.password);
         if (!isInstallerEnabled) {
             setPort(services.webPort);
-            setPassword(services.password);
             enableInstaller(window);
         }
     } else {


### PR DESCRIPTION
Before, when the user changed the  installer service password in the Settings screen, was required to disable and re-enable the installer to make it take effect, now only the port requires that, the password changes immediatly.