### PR TITLE
refactor: dynamically generate recent files submenu and increase recent file limits

### DIFF
--- a/src/menu/fileMenuTemplate.js
+++ b/src/menu/fileMenuTemplate.js
@@ -30,12 +30,12 @@ function buildRecentSubmenu() {
         }
         items.push(entry);
     }
-    items.push({
-        id: "zip-empty",
-        label: "No app .zip/.bpk file Recently Opened",
-        enabled: false,
-    });
     items.push(
+        {
+            id: "zip-empty",
+            label: "No app .zip/.bpk file Recently Opened",
+            enabled: false,
+        },
         { type: "separator" },
         {
             id: "file-clear",

--- a/src/menu/fileMenuTemplate.js
+++ b/src/menu/fileMenuTemplate.js
@@ -11,6 +11,42 @@ import { closeChannel } from "../helpers/window";
 import { loadUrl } from "../helpers/files";
 import { loadPackage, clearRecentFiles } from "./menuService";
 
+export const maxMenuFiles = 15;
+
+// Generate recent file menu items dynamically
+function buildRecentSubmenu() {
+    const items = [];
+    for (let i = 0; i < maxMenuFiles; i++) {
+        const entry = {
+            id: `zip-${i}`,
+            label: "",
+            visible: false,
+            click: () => {
+                loadPackage(i);
+            },
+        };
+        if (i === 0) {
+            entry.accelerator = "CmdOrCtrl+R";
+        }
+        items.push(entry);
+    }
+    items.push({
+        id: "zip-empty",
+        label: "No app .zip/.bpk file Recently Opened",
+        enabled: false,
+    });
+    items.push({ type: "separator" });
+    items.push({
+        id: "file-clear",
+        label: "Clear Recently Opened",
+        enabled: false,
+        click: () => {
+            clearRecentFiles();
+        },
+    });
+    return items;
+}
+
 export const fileMenuTemplate = {
     label: "&File",
     submenu: [
@@ -54,79 +90,7 @@ export const fileMenuTemplate = {
         {
             id: "file-open-recent",
             label: "Open Recent",
-            submenu: [
-                {
-                    id: "zip-0",
-                    label: "",
-                    accelerator: "CmdOrCtrl+R",
-                    visible: false,
-                    click: (item, window) => {
-                        loadPackage(0);
-                    },
-                },
-                {
-                    id: "zip-1",
-                    label: "",
-                    visible: false,
-                    click: (item, window) => {
-                        loadPackage(1);
-                    },
-                },
-                {
-                    id: "zip-2",
-                    label: "",
-                    visible: false,
-                    click: (item, window) => {
-                        loadPackage(2);
-                    },
-                },
-                {
-                    id: "zip-3",
-                    label: "",
-                    visible: false,
-                    click: (item, window) => {
-                        loadPackage(3);
-                    },
-                },
-                {
-                    id: "zip-4",
-                    label: "",
-                    visible: false,
-                    click: (item, window) => {
-                        loadPackage(4);
-                    },
-                },
-                {
-                    id: "zip-5",
-                    label: "",
-                    visible: false,
-                    click: (item, window) => {
-                        loadPackage(5);
-                    },
-                },
-                {
-                    id: "zip-6",
-                    label: "",
-                    visible: false,
-                    click: (item, window) => {
-                        loadPackage(6);
-                    },
-                },
-                {
-                    id: "zip-empty",
-                    label: "No app .zip/.bpk file Recently Opened",
-                    enabled: false,
-                },
-                { type: "separator" },
-                {
-                    id: "file-clear",
-                    label: "Clear Recently Opened",
-                    enabled: false,
-                    click: (item, window) => {
-                        clearRecentFiles();
-                    },
-                },
-            ],
+            submenu: buildRecentSubmenu(),
         },
         { type: "separator" },
         {

--- a/src/menu/fileMenuTemplate.js
+++ b/src/menu/fileMenuTemplate.js
@@ -35,15 +35,17 @@ function buildRecentSubmenu() {
         label: "No app .zip/.bpk file Recently Opened",
         enabled: false,
     });
-    items.push({ type: "separator" });
-    items.push({
-        id: "file-clear",
-        label: "Clear Recently Opened",
-        enabled: false,
-        click: () => {
-            clearRecentFiles();
+    items.push(
+        { type: "separator" },
+        {
+            id: "file-clear",
+            label: "Clear Recently Opened",
+            enabled: false,
+            click: () => {
+                clearRecentFiles();
+            },
         },
-    });
+    );
     return items;
 }
 
@@ -75,9 +77,10 @@ export const fileMenuTemplate = {
                         height: 177,
                         icon: __dirname + "/images/icon.ico",
                         type: "input",
-                        customStylesheet: __dirname + `/css/prompt-${userTheme}.css`,
+                        customStylesheet:
+                            __dirname + `/css/prompt-${userTheme}.css`,
                     },
-                    window
+                    window,
                 )
                     .then((url) => {
                         if (url) {

--- a/src/menu/menuService.js
+++ b/src/menu/menuService.js
@@ -7,7 +7,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { app, BrowserWindow, Menu, ipcMain } from "electron";
 import { macOSMenuTemplate } from "./macOSMenuTemplate";
-import { fileMenuTemplate } from "./fileMenuTemplate";
+import { fileMenuTemplate, maxMenuFiles } from "./fileMenuTemplate";
 import {
     editMenuTemplate,
     editSettingsMenuTemplate,
@@ -28,8 +28,7 @@ import jetpack from "fs-jetpack";
 import "../helpers/hash";
 
 const isMacOS = process.platform === "darwin";
-const maxFiles = 21;
-const maxMenuFiles = 7;
+const maxFiles = 30;
 const userDataDir = jetpack.cwd(app.getPath("userData"));
 const recentFilesJson = "recent-files.json";
 const recentMenuIndex = 2;


### PR DESCRIPTION
Increases the maximum number of stored recent files from 21 to 30 and the number of recent files shown in the "Open Recent" menu from 7 to 15. Refactors the menu item generation to be dynamic, preventing out-of-bounds exceptions when the constants are changed.

### Problem

Previously, the "Open Recent" submenu in `fileMenuTemplate.js` had exactly 7 hardcoded menu item entries (`zip-0` through `zip-6`). The `rebuildMenu()` function in `menuService.js` iterated up to `maxMenuFiles` to update these entries by index (template path on macOS) or by ID lookup (Windows/Linux). Simply changing the `maxMenuFiles` constant without adding corresponding menu items caused an exception — the loop tried to access entries that didn't exist in the template.

### Changes

- **`src/menu/fileMenuTemplate.js`**
  - Replaced 7 hardcoded `zip-N` menu items with a `buildRecentSubmenu()` function that programmatically generates all entries based on the `maxMenuFiles` constant.
  - Exported `maxMenuFiles = 15` as the single source of truth for both files.

- **`src/menu/menuService.js`**
  - Changed `maxFiles` from `21` to `30` (total recent files stored in `recent-files.json`).
  - Removed the local `maxMenuFiles` constant and imports it from `fileMenuTemplate.js` instead.

### Backward Compatibility

- Existing `recent-files.json` files with ≤21 entries are loaded without issues — the arrays simply grow as new files are added.
- `restoreRecentFiles()` already handles missing or legacy fields (`ids`, `names`, `versions`) by backfilling defaults, so no data migration is needed.

---

Let me know if you'd like to adjust the wording or add anything (e.g., a testing section, issue reference, etc.).