### PR TITLE
feat: Home key interception to exit apps even with debugger active

### DIFF
--- a/src/app/preload.js
+++ b/src/app/preload.js
@@ -23,9 +23,9 @@ globalThis.addEventListener("DOMContentLoaded", () => {
         getCurrentWebContents().send("copyScreenshot");
         return false;
     });
-    // Intercept Cmd+V / Ctrl+V in capture phase to prevent "v" from reaching brs-engine
-    // Only apply in the main simulator window (which has the #display canvas)
+    // Only apply keyboard interceptions in the main simulator window (which has the #display canvas)
     if (document.getElementById("display")) {
+        // Intercept Cmd+V / Ctrl+V in capture phase to prevent "v" from reaching brs-engine
         document.addEventListener("keydown", function (e) {
             if ((e.metaKey || e.ctrlKey) && e.key === "v") {
                 e.preventDefault();
@@ -37,8 +37,88 @@ globalThis.addEventListener("DOMContentLoaded", () => {
                 }
             }
         }, true); // capture phase fires before brs-engine's bubbling-phase handler
+
+        // Intercept the Home remote key to act as "Close App"
+        let homeKeyCode = convertSettingsKey(
+            ipcRenderer.sendSync("getPreferences")?.remote?.keyHome ?? "Home"
+        );
+        document.addEventListener("keydown", function (e) {
+            if (matchesKey(e, homeKeyCode)) {
+                e.preventDefault();
+                e.stopImmediatePropagation();
+                getCurrentWebContents().send("closeChannel", "EXIT_USER_NAV");
+            }
+        }, true); // capture phase fires before brs-engine's bubbling-phase handler
+
+        // Update the Home key binding when preferences change
+        ipcRenderer.on("preferencesUpdated", (_, preferences) => {
+            if (preferences?.remote?.keyHome) {
+                homeKeyCode = convertSettingsKey(preferences.remote.keyHome);
+            }
+        });
     }
 });
+
+// Convert a Settings key name to KeyboardEvent.code format
+// Mirrors the convertKey/convertChar logic from settings.js
+function convertSettingsKey(keyCode) {
+    if (!keyCode) {
+        return "Home";
+    }
+    const arrows = new Set(["Left", "Right", "Up", "Down"]);
+    let newCode = keyCode.replaceAll(" ", "");
+    if (keyCode.includes("+")) {
+        const parts = keyCode.split("+");
+        const leftKey = parts[0];
+        const rightKey = parts[1];
+        if (rightKey.length === 1) {
+            newCode = `${leftKey}+${convertSettingsChar(rightKey)}`;
+        } else if (arrows.has(rightKey)) {
+            newCode = `${leftKey}+Arrow${rightKey}`;
+        }
+    } else if (keyCode.length === 1) {
+        newCode = convertSettingsChar(keyCode);
+    } else if (arrows.has(keyCode)) {
+        newCode = `Arrow${keyCode}`;
+    }
+    return newCode;
+}
+
+function convertSettingsChar(keyChar) {
+    if (/^[0-9]$/.test(keyChar)) {
+        return `Digit${keyChar}`;
+    } else if (/^[a-zA-Z]$/.test(keyChar)) {
+        return `Key${keyChar.toUpperCase()}`;
+    }
+    const keyMap = {
+        "`": "Backquote", "-": "Minus", "=": "Equal",
+        "[": "BracketLeft", "]": "BracketRight", ";": "Semicolon",
+        "'": "Quote", ",": "Comma", ".": "Period",
+        "\\": "Backslash", "/": "Slash",
+    };
+    return keyMap[keyChar] ?? keyChar;
+}
+
+// Check if a KeyboardEvent matches a converted key code
+// Supports modifier+key combos (e.g. "Shift+KeyA")
+function matchesKey(event, keyCode) {
+    if (keyCode.includes("+")) {
+        const parts = keyCode.split("+");
+        const modifier = parts[0].toLowerCase();
+        const code = parts[1];
+        const hasModifier =
+            (modifier === "shift" && event.shiftKey) ||
+            (modifier === "control" && event.ctrlKey) ||
+            (modifier === "alt" && event.altKey) ||
+            (modifier === "meta" && event.metaKey) ||
+            (modifier === "shiftleft" && event.shiftKey) ||
+            (modifier === "shiftright" && event.shiftKey) ||
+            (modifier === "controlleft" && event.ctrlKey) ||
+            (modifier === "controlright" && event.ctrlKey);
+        return hasModifier && event.code === code;
+    }
+    return event.code === keyCode && !event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey;
+}
 
 contextBridge.exposeInMainWorld("api", {
     showPreferences: () => {

--- a/src/app/preload.js
+++ b/src/app/preload.js
@@ -85,7 +85,7 @@ function convertSettingsKey(keyCode) {
 }
 
 function convertSettingsChar(keyChar) {
-    if (/^[0-9]$/.test(keyChar)) {
+    if (/^\d$/.test(keyChar)) {
         return `Digit${keyChar}`;
     } else if (/^[a-zA-Z]$/.test(keyChar)) {
         return `Key${keyChar.toUpperCase()}`;


### PR DESCRIPTION
This PR implements a feature to intercept the configured **Home** remote key to reliably trigger the "Close App" action in the simulator, replicating the behavior of the `File -> Close App` menu option.

By intercepting the keyboard event in the `capture` phase before it bubbles down to the `brs-engine`, we ensure that pressing the Home key gracefully exits the app even if the engine is suspended or the micro-debugger is active. 

### Changes Made
*   **Key Interception**: Added a capture-phase `keydown` listener in `src/app/preload.js` to intercept the Home key.
*   **Dynamic Settings Support**: 
    *   Reads the initial `remote.keyHome` value from user preferences on load.
    *   Added a listener for the `preferencesUpdated` IPC event to dynamically update the intercepted key binding without requiring an app restart.
*   **Key Conversion Logic**: Added utility functions (`convertSettingsKey`, `convertSettingsChar`, `matchesKey`) in the preload script to map the user's configured Settings string (e.g., `"Home"`, `"Shift+F5"`, `"A"`) to the browser's `KeyboardEvent.code` format. This mirrors the `convertKey` logic used natively by `brs-engine` in `settings.js`.
*   **Action Dispatch**: When the Home key is detected, it prevents event propagation and triggers the `closeChannel` IPC event with the `"EXIT_USER_NAV"` reason.

### How to Test
1. Launch the simulator and ensure a channel is running.
2. Press the `Home` key on your keyboard. The app should close gracefully.
3. Open **Settings -> Remote Control** and change the Home button mapping (e.g. to `F12` or `Shift+H`).
4. Launch an app again and press your new custom Home key. It should successfully close the app.
5. Trigger the debugger (e.g., using a crash or a `stop` statement) and press the Home key. The app should still intercept the key and exit correctly.
