### PR TITLE
fix: restrict clipboard copy shortcut to platform-specific key combination

### DIFF
--- a/src/app/preload.js
+++ b/src/app/preload.js
@@ -19,7 +19,7 @@ let titleColor;
 
 globalThis.addEventListener("DOMContentLoaded", () => {
     // Detect Clipboard Copy to create Screenshot
-    Mousetrap.bind(["command+c", "ctrl+c"], function () {
+    Mousetrap.bind(isMacOS ? "command+c" : "ctrl+c", function () {
         getCurrentWebContents().send("copyScreenshot");
         return false;
     });


### PR DESCRIPTION
The `Ctrl+C` was in conflict in MacOS with the break command, this fixes it.