### PR TITLE
feat: enhance toast system with click-to-disable functionality and add DevTools performance warning

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -469,7 +469,8 @@ display.ondblclick = function () {
 // Warn user to use keyboard
 display.onclick = function () {
     const settings = api.getPreferences();
-    const displayToast = !settings?.simulator?.options?.includes("disableClickToast");
+    const options = settings?.simulator?.options ?? [];
+    const displayToast = !options.includes("disableClickToast");
     if (currentApp.running && displayToast) {
         // Delay the toast to allow double-click to cancel it
         if (clickTimeout) {
@@ -477,8 +478,17 @@ display.onclick = function () {
         }
         clickTimeout = setTimeout(() => {
             showToast(
-                "Use the keyboard or a gamepad to interact with the app. Double click toggles full screen.",
-                5000
+                "Use the keyboard or a gamepad to interact with the app. Double click toggles full screen. Click here to disable this warning.",
+                7000,
+                false,
+                function () {
+                    const currentSettings = api.getPreferences();
+                    const currentOptions = currentSettings?.simulator?.options ?? [];
+                    if (!currentOptions.includes("disableClickToast")) {
+                        currentOptions.push("disableClickToast");
+                        api.setPreference("simulator.options", currentOptions);
+                    }
+                }
             );
             clickTimeout = null;
         }, 250); // 250ms delay to detect double-click

--- a/src/app/preload.js
+++ b/src/app/preload.js
@@ -127,6 +127,9 @@ contextBridge.exposeInMainWorld("api", {
     getPreferences: () => {
         return ipcRenderer.sendSync("getPreferences");
     },
+    setPreference: (key, value) => {
+        ipcRenderer.send("setPreference", key, value);
+    },
     onPreferencesUpdated: (handler) => {
         onPreferencesUpdatedHandler = handler;
     },
@@ -215,6 +218,7 @@ contextBridge.exposeInMainWorld("api", {
             "openAppPackage",
             "closeSimulator",
             "externalVolumeReady",
+            "setPreference",
         ];
         if (validChannels.includes(channel)) {
             ipcRenderer.send(channel, data);

--- a/src/app/statusbar.js
+++ b/src/app/statusbar.js
@@ -203,9 +203,9 @@ function shortenPath(bigPath, maxLen) {
 }
 
 // Function to display a Toast (from the bottom) with messages to the user
-export function showToast(message, duration = 3000, error = false) {
+export function showToast(message, duration = 3000, error = false, onClick = null) {
     const toastColor = error ? "--status-error-color" : "--status-background-color";
-    Toastify({
+    const options = {
         text: message,
         duration: duration,
         close: false,
@@ -217,7 +217,15 @@ export function showToast(message, duration = 3000, error = false) {
             background: colorValues.getPropertyValue(toastColor).trim(),
             fontSize: "14px",
         },
-    }).showToast();
+    };
+    if (typeof onClick === "function") {
+        options.onClick = function () {
+            toast.hideToast();
+            onClick();
+        };
+    }
+    const toast = Toastify(options);
+    toast.showToast();
 }
 
 // Events from Main process

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -1413,6 +1413,10 @@ export function getAudioMuted() {
     return muted[0] ? muted[0] : false;
 }
 
+ipcMain.on("setPreference", (_, key, value) => {
+    setPreference(key, value);
+});
+
 ipcMain.on("setAudioMute", (event, mute) => {
     settings.value("audio.muted", mute ? [mute] : []);
 });

--- a/src/helpers/window.js
+++ b/src/helpers/window.js
@@ -163,6 +163,14 @@ export function createWindow(name, options) {
 
 export function openDevTools(window) {
     window.openDevTools({ mode: "detach" });
+    if (window.id === 1) {
+        window.webContents.send(
+            "showToast",
+            "Warning: DevTools severely impacts interpreter performance. Once you close it, use Device > Reset Device in the menu to restore the performance.",
+            10000,
+            true
+        );
+    }
 }
 
 export function setAspectRatio(changed = true) {


### PR DESCRIPTION
Two changes on this PR:
- The warning for mouse click on the display window now can be disabled by clicking the toast
- Added a new toast with a warning for the performance degradation caused by the Developer Tools.