### PR TITLE
fix(ecp): answer device queries during the pre-deviceData startup window

### DIFF
--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -1496,7 +1496,9 @@ ipcMain.on("externalVolumeReady", (event) => {
 });
 
 export function getModelName(model) {
-    const modelName = globalThis.sharedObject.deviceInfo.models.get(model);
+    // See the note on the matching helper in src/server/ecp.js: `models` only exists once
+    // the renderer has sent deviceData.
+    const modelName = globalThis.sharedObject.deviceInfo.models?.get(model);
     return modelName ? modelName[0].replace(/ *\([^)]*\) */g, "") : `Roku (${model})`;
 }
 

--- a/src/server/ecp.js
+++ b/src/server/ecp.js
@@ -539,7 +539,8 @@ export function genAppRegistry(plugin, encrypt) {
         const secsXml = regXml.ele("sections");
         let curSection = "";
         let scXml, itsXml, itXml;
-        const registry = new Map([...device.registry].sort());
+        // Same startup window as getModelName: spreading an undefined registry would throw.
+        const registry = new Map([...(device.registry ?? [])].sort());
         for (const [key, value] of registry) {
             const sections = key.split(".");
             if (sections.length > 2 && sections[0] === device.developerId) {
@@ -640,6 +641,9 @@ function getAppIconPath(appID) {
 }
 
 export function getModelName(model) {
-    const modelName = device.models.get(model);
+    // `models` is populated by the renderer's deviceData message, so it is absent for the
+    // first moments after startup. The generic fallback below already covers an unknown
+    // model; without the optional chaining it is unreachable and the caller 500s instead.
+    const modelName = device.models?.get(model);
     return modelName ? modelName[0].replace(/ *\([^)]*\) */g, "") : `Roku (${model})`;
 }

--- a/src/server/ecp.js
+++ b/src/server/ecp.js
@@ -540,7 +540,17 @@ export function genAppRegistry(plugin, encrypt) {
         let curSection = "";
         let scXml, itsXml, itXml;
         // Same startup window as getModelName: spreading an undefined registry would throw.
-        const registry = new Map([...(device.registry ?? [])].sort());
+        // Sorted explicitly by key: a bare .sort() compares the "key,value" string each
+        // entry coerces to, which happens to order by key but only by accident. Registry
+        // keys are unique, so comparing them alone is equivalent and says what it means.
+        const registry = new Map(
+            [...(device.registry ?? [])].sort(([keyA], [keyB]) => {
+                if (keyA === keyB) {
+                    return 0;
+                }
+                return keyA < keyB ? -1 : 1;
+            })
+        );
         for (const [key, value] of registry) {
             const sections = key.split(".");
             if (sections.length > 2 && sections[0] === device.developerId) {

--- a/test/integration/ecp-rest.spec.js
+++ b/test/integration/ecp-rest.spec.js
@@ -7,7 +7,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
 import { createFakeWindow, __registerWindow, ipcMain } from "../mocks/electron.js";
-import { makeSharedObject, makeEngineDeviceInfo } from "../fixtures/sharedObject.js";
+import { makeSharedObject, makeDeviceInfo, makeEngineDeviceInfo } from "../fixtures/sharedObject.js";
 import { getFreePort } from "../helpers/freePort.js";
 import {
     initECP,
@@ -171,5 +171,54 @@ describe("ECP REST API", () => {
                 expect(response.status).toBeGreaterThanOrEqual(400);
             }
         );
+    });
+});
+
+describe("ECP REST API before the renderer reports device data", () => {
+    // makeDeviceInfo() is the object main.js builds at startup: no `models`, no `registry`.
+    // A client that queries in the window before the renderer's first deviceData message
+    // used to get a 500; it should get a usable answer instead.
+    let win;
+    let base;
+
+    beforeAll(async () => {
+        globalThis.sharedObject = makeSharedObject(makeDeviceInfo());
+        win = __registerWindow(createFakeWindow(1));
+        const port = await getFreePort();
+        initECP();
+        await new Promise((resolve) => {
+            subscribeECP("test-startup", (event, enabled) => {
+                if (event === "enabled" && enabled) {
+                    resolve();
+                }
+            });
+            enableECP(win, port);
+        });
+        unsubscribeECP("test-startup");
+        base = `http://127.0.0.1:${port}`;
+    });
+
+    afterAll(() => {
+        disableECP();
+    });
+
+    it("answers device-info with a generic model name rather than 500", async () => {
+        const response = await fetch(`${base}/query/device-info`);
+        expect(response.status).toBe(200);
+        const body = await response.text();
+        expect(body).toContain("Roku (4200X)");
+        expect(body).toContain("<device-info>");
+    });
+
+    it("answers the app registry rather than 500", async () => {
+        const response = await fetch(`${base}/query/registry/dev`);
+        expect(response.status).toBe(200);
+        expect(await response.text()).toContain("<dev-id>brs-dev-id</dev-id>");
+    });
+
+    it("serves the UPnP root rather than 500", async () => {
+        const response = await fetch(`${base}/`);
+        expect(response.status).toBe(200);
+        expect(await response.text()).toContain("<modelName>");
     });
 });

--- a/test/unit/server/ecp-xml.spec.js
+++ b/test/unit/server/ecp-xml.spec.js
@@ -99,13 +99,18 @@ describe("ECP payload builders", () => {
             expect(genDeviceInfoXml(false)).not.toContain("virtual-device-id");
         });
 
-        // Design hazard: device.models arrives from the renderer via the deviceData IPC,
-        // and is absent from the object main.js builds at startup. An ECP client that
-        // queries between enableECP() and that first message gets a 500.
-        it("throws when queried before the renderer has reported device data", () => {
+        // device.models arrives from the renderer via the deviceData IPC and is absent from
+        // the object main.js builds at startup, so an ECP client can query in that window --
+        // the VS Code BrightScript extension polls on connect. Answering with the generic
+        // model name beats returning a 500.
+        it("falls back to a generic model name before the renderer has reported device data", () => {
             globalThis.sharedObject = makeSharedObject(makeDeviceInfo());
             initECP();
-            expect(() => genDeviceInfoXml(false)).toThrow();
+            const xml = genDeviceInfoXml(false);
+            // The serial number also arrives with deviceData, so it is legitimately blank
+            // here; what matters is that the model falls back instead of throwing.
+            expect(xml).toContain("Roku (4200X)");
+            expect(xml).toContain("<device-info>");
         });
     });
 


### PR DESCRIPTION
## Problem

`device.models` and `device.registry` are absent from the device object `src/main.js` builds at startup — both arrive later from the renderer via the `deviceData` IPC message. An ECP client that queries in between hits a `TypeError` and gets a **500** on the wire.

The window is reachable in practice: the VS Code BrightScript extension polls on connect, and `--ecp` starts the server before the renderer is ready.

Pinned by `test/unit/server/ecp-xml.spec.js` in #296 as *"throws when queried before the renderer has reported device data"*.

## Fix

`getModelName` already had the right answer for an unknown model — `` `Roku (${model})` `` — sitting one line below the throwing `.get()`. Optional chaining makes that existing fallback reachable rather than adding new behaviour:

```js
const modelName = device.models?.get(model);
return modelName ? modelName[0].replace(/ *\([^)]*\) */g, "") : `Roku (${model})`;
```

Two more instances of the same hazard:
- `genAppRegistry` spreads `device.registry` into a `Map`, which throws on `undefined` → `?? []`
- `src/helpers/settings.js` carries a duplicate `getModelName` with the identical unguarded lookup

## Tests

- The pinned unit test now asserts the fallback instead of the throw.
- Three new integration tests boot ECP with `makeDeviceInfo()` (the startup-shaped fixture, no `models`/`registry`) and assert `/query/device-info`, `/query/registry/dev` and `/` all return **200**.
- Confirmed the tests fail before the source change with `TypeError: Cannot read properties of undefined (reading 'get')` — the exact error behind the 500.

533 passing. Verified against the running app: `curl /query/device-info` immediately after `--ecp` launch returns 200.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)