### PR TITLE
fix(preload): stop custom key bindings firing on unrelated chords

### DIFF
--- a/src/app/preloadKeys.js
+++ b/src/app/preloadKeys.js
@@ -135,16 +135,21 @@ function matchesKey(event, keyCode) {
         const parts = keyCode.split("+");
         const modifier = parts[0].toLowerCase();
         const code = parts[1];
-        const hasModifier =
-            (modifier === "shift" && event.shiftKey) ||
-            (modifier === "control" && event.ctrlKey) ||
-            (modifier === "alt" && event.altKey) ||
-            (modifier === "meta" && event.metaKey) ||
-            (modifier === "shiftleft" && event.shiftKey) ||
-            (modifier === "shiftright" && event.shiftKey) ||
-            (modifier === "controlleft" && event.ctrlKey) ||
-            (modifier === "controlright" && event.ctrlKey);
-        return hasModifier && event.code === code;
+        const wantsShift = modifier === "shift" || modifier === "shiftleft" || modifier === "shiftright";
+        const wantsControl =
+            modifier === "control" || modifier === "controlleft" || modifier === "controlright";
+        const wantsAlt = modifier === "alt";
+        const wantsMeta = modifier === "meta";
+        // The binding names the modifiers it wants, so anything else held is a different
+        // chord: Ctrl+Shift+A must not satisfy a "Shift+KeyA" binding. The bare-key branch
+        // below has always required every modifier to be absent; this keeps the two consistent.
+        return (
+            event.code === code &&
+            event.shiftKey === wantsShift &&
+            event.ctrlKey === wantsControl &&
+            event.altKey === wantsAlt &&
+            event.metaKey === wantsMeta
+        );
     }
     return event.code === keyCode && !event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey;
 }

--- a/test/unit/app/preloadKeys.spec.js
+++ b/test/unit/app/preloadKeys.spec.js
@@ -163,9 +163,13 @@ describe("matchesKey", () => {
         expect(matchesKey(keyEvent("KeyA", { shiftKey: true }), "SHIFT+KeyA")).toBe(true);
     });
 
-    it("ignores extra modifiers in a combination", () => {
-        // Characterization: only the named modifier is checked, so Ctrl+Shift+A also
-        // satisfies a "Shift+KeyA" binding.
-        expect(matchesKey(keyEvent("KeyA", { shiftKey: true, ctrlKey: true }), "Shift+KeyA")).toBe(true);
+    it("rejects a combination when an unnamed modifier is also held", () => {
+        // A binding names the modifiers it wants; anything else held means the user pressed
+        // a different chord. The bare-key branch above has always enforced this.
+        expect(matchesKey(keyEvent("KeyA", { shiftKey: true, ctrlKey: true }), "Shift+KeyA")).toBe(false);
+        expect(matchesKey(keyEvent("KeyA", { shiftKey: true, altKey: true }), "Shift+KeyA")).toBe(false);
+        expect(matchesKey(keyEvent("KeyA", { shiftKey: true, metaKey: true }), "Shift+KeyA")).toBe(false);
+        // The named modifier on its own still matches.
+        expect(matchesKey(keyEvent("KeyA", { shiftKey: true }), "Shift+KeyA")).toBe(true);
     });
 });


### PR DESCRIPTION
## Problem

`matchesKey` in `src/app/preloadKeys.js` had two branches that disagreed with each other:

```js
// combination branch — checks only that the NAMED modifier is held
return hasModifier && event.code === code;

// bare-key branch, on the very next line — requires all four absent
return event.code === keyCode && !event.shiftKey && !event.ctrlKey && !event.altKey && !event.metaKey;
```

So a binding of `Shift+KeyA` also matched `Ctrl+Shift+A`, `Alt+Shift+A` and `Cmd+Shift+A`.

This is the matcher behind the preload's capture-phase key interception, so a user who remaps Home to a chord could **exit the running app** by pressing an unrelated shortcut that shared the named modifier.

Pinned by `test/unit/app/preloadKeys.spec.js` in #296 as *"ignores extra modifiers in a combination"*.

## Fix

The combination branch now compares all four modifier flags against what the binding asks for — the same rule the bare-key branch has always applied.

Sided aliases (`ShiftLeft`, `ControlRight`, …) keep working: they set the same expectation as their unsided form, because a `KeyboardEvent` only reports the generic `shiftKey` / `ctrlKey` flag.

## Tests

The pinned test flips to `toBe(false)` and gains cases for each unnamed modifier, plus a positive case confirming the named modifier alone still matches. Confirmed failing before the change.

530 passing. Also exercised the **built** `app/preloadKeys.js` directly, since that file is copied unbundled rather than webpacked:

```
Shift+A on Shift+KeyA  -> true   (want true)
Ctrl+Shift+A on same   -> false  (want false)
ShiftLeft alias        -> true   (want true)
bare Home              -> true   (want true)
```

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)