### PR TITLE
fix(keys): support remote shortcuts with more than one modifier

### DIFF
--- a/src/app/preloadKeys.js
+++ b/src/app/preloadKeys.js
@@ -85,22 +85,17 @@ function convertSettingsKey(keyCode) {
         return "Home";
     }
     const arrows = new Set(["Left", "Right", "Up", "Down"]);
-    let newCode = keyCode.replaceAll(" ", "");
-    if (keyCode.includes("+")) {
-        const parts = keyCode.split("+");
-        const leftKey = parts[0];
-        const rightKey = parts[1];
-        if (rightKey.length === 1) {
-            newCode = `${leftKey}+${convertSettingsChar(rightKey)}`;
-        } else if (arrows.has(rightKey)) {
-            newCode = `${leftKey}+Arrow${rightKey}`;
-        }
-    } else if (keyCode.length === 1) {
-        newCode = convertSettingsChar(keyCode);
-    } else if (arrows.has(keyCode)) {
-        newCode = `Arrow${keyCode}`;
+    // The last segment is the key; everything before it is a modifier. Mirrors convertKey
+    // in src/helpers/keyCodes.js — see the parity spec.
+    const parts = keyCode.replaceAll(" ", "").split("+");
+    const key = parts.at(-1);
+    let converted = key;
+    if (key.length === 1) {
+        converted = convertSettingsChar(key);
+    } else if (arrows.has(key)) {
+        converted = `Arrow${key}`;
     }
-    return newCode;
+    return [...parts.slice(0, -1), converted].join("+");
 }
 
 /**
@@ -133,13 +128,15 @@ function convertSettingsChar(keyChar) {
 function matchesKey(event, keyCode) {
     if (keyCode.includes("+")) {
         const parts = keyCode.split("+");
-        const modifier = parts[0].toLowerCase();
-        const code = parts[1];
-        const wantsShift = modifier === "shift" || modifier === "shiftleft" || modifier === "shiftright";
-        const wantsControl =
-            modifier === "control" || modifier === "controlleft" || modifier === "controlright";
-        const wantsAlt = modifier === "alt";
-        const wantsMeta = modifier === "meta";
+        // Every segment but the last is a modifier, so three-part chords work too.
+        const code = parts.at(-1);
+        const modifiers = parts.slice(0, -1).map((part) => part.toLowerCase());
+        const wants = (...names) => modifiers.some((modifier) => names.includes(modifier));
+        // A KeyboardEvent only reports the generic flag, so the sided aliases map onto it.
+        const wantsShift = wants("shift", "shiftleft", "shiftright");
+        const wantsControl = wants("control", "controlleft", "controlright");
+        const wantsAlt = wants("alt");
+        const wantsMeta = wants("meta");
         // The binding names the modifiers it wants, so anything else held is a different
         // chord: Ctrl+Shift+A must not satisfy a "Shift+KeyA" binding. The bare-key branch
         // below has always required every modifier to be absent; this keeps the two consistent.

--- a/src/helpers/keyCodes.js
+++ b/src/helpers/keyCodes.js
@@ -20,21 +20,18 @@
  */
 export function convertKey(keyCode) {
     const arrows = new Set(["Left", "Right", "Up", "Down"]);
-    let newCode = keyCode.replaceAll(" ", "");
-    if (keyCode.includes("+")) {
-        const leftKey = keyCode.split("+")[0];
-        const rightKey = keyCode.split("+")[1];
-        if (rightKey.length === 1) {
-            newCode = `${leftKey}+${convertChar(rightKey)}`;
-        } else if (arrows.has(rightKey)) {
-            newCode = `${leftKey}+Arrow${rightKey}`;
-        }
-    } else if (keyCode.length === 1) {
-        newCode = convertChar(keyCode);
-    } else if (arrows.has(keyCode)) {
-        newCode = `Arrow${keyCode}`;
+    // The last segment is the key; everything before it is a modifier. Reading only the
+    // first two segments would leave the key of a three-part chord unconverted, and the
+    // renderer would never match the binding.
+    const parts = keyCode.replaceAll(" ", "").split("+");
+    const key = parts.at(-1);
+    let converted = key;
+    if (key.length === 1) {
+        converted = convertChar(key);
+    } else if (arrows.has(key)) {
+        converted = `Arrow${key}`;
     }
-    return newCode;
+    return [...parts.slice(0, -1), converted].join("+");
 }
 
 /**

--- a/test/unit/app/preloadKeys.parity.spec.js
+++ b/test/unit/app/preloadKeys.parity.spec.js
@@ -24,6 +24,7 @@ const SHARED_KEYS = [
     "Left", "Right", "Up", "Down",
     "A", "M", "Z", "0", "5", "9",
     "Shift+A", "Control+Left", "Alt+Down", "Meta+M",
+    "Control+Shift+A", "Control+Alt+Left", "Meta+Shift+Z",
     "Page Up", "Page Down",
     "`", "-", "=", "[", "]", ";", ",", ".", "\\", "/",
 ];

--- a/test/unit/app/preloadKeys.spec.js
+++ b/test/unit/app/preloadKeys.spec.js
@@ -159,6 +159,14 @@ describe("matchesKey", () => {
         }
     );
 
+    it("matches a three-part chord", () => {
+        const held = { shiftKey: true, ctrlKey: true };
+        expect(matchesKey(keyEvent("KeyA", held), "Control+Shift+KeyA")).toBe(true);
+        // ...and still rejects it when one of the named modifiers is missing.
+        expect(matchesKey(keyEvent("KeyA", { shiftKey: true }), "Control+Shift+KeyA")).toBe(false);
+        expect(matchesKey(keyEvent("KeyA", { ...held, altKey: true }), "Control+Shift+KeyA")).toBe(false);
+    });
+
     it("is case insensitive about the modifier name", () => {
         expect(matchesKey(keyEvent("KeyA", { shiftKey: true }), "SHIFT+KeyA")).toBe(true);
     });

--- a/test/unit/helpers/keyCodes.spec.js
+++ b/test/unit/helpers/keyCodes.spec.js
@@ -95,12 +95,11 @@ describe("convertKey", () => {
         expect(convertKey("Control+Home")).toBe("Control+Home");
     });
 
-    // Characterization: only the first two segments are inspected. A three-part chord has
-    // a multi-character second segment, so no branch matches and the whole string passes
-    // through with spaces stripped — the trailing "+A" is never converted to "+KeyA".
-    it("leaves a three-part combination unconverted", () => {
-        expect(convertKey("Control+Shift+A")).toBe("Control+Shift+A");
-        expect(convertKey("Control + Shift + A")).toBe("Control+Shift+A");
+    it("converts the key of a three-part combination", () => {
+        expect(convertKey("Control+Shift+A")).toBe("Control+Shift+KeyA");
+        expect(convertKey("Control + Shift + A")).toBe("Control+Shift+KeyA");
+        expect(convertKey("Control+Alt+Left")).toBe("Control+Alt+ArrowLeft");
+        expect(convertKey("Control+Shift+Enter")).toBe("Control+Shift+Enter");
     });
 });
 


### PR DESCRIPTION
> **Stacked on #298** — base is `fix/matcheskey-exact-modifiers`, not `master`. Merge that one first and this retargets automatically.

## Problem

`convertKey` (`src/helpers/keyCodes.js`) and `convertSettingsKey` (`src/app/preloadKeys.js`) read only `split("+")[0]` and `[1]`:

```js
const leftKey = keyCode.split("+")[0];
const rightKey = keyCode.split("+")[1];   // "Shift" for a three-part chord
```

So `Control+Shift+A` fell through every branch and was stored with its key unconverted. `matchesKey` then read `parts[1]` — `"Shift"` — as the key code, which no `KeyboardEvent` ever reports.

**A user who configured a three-key remote shortcut got a binding that could never fire.**

Pinned by `test/unit/helpers/keyCodes.spec.js` in #296 as *"leaves a three-part combination unconverted"*.

## Fix

Both halves had to change together — converting the key alone would still leave the matcher looking at the wrong segment, so the shortcut would stay dead.

All three functions now treat **the last segment as the key** and everything before it as modifiers:

```js
const parts = keyCode.replaceAll(" ", "").split("+");
const key = parts.at(-1);
return [...parts.slice(0, -1), converted].join("+");
```

Two-part chords and bare keys are unaffected — they're the same code path with one or zero modifiers.

## Tests

- The pinned test now expects `Control+Shift+KeyA`, plus arrow and named-key chords.
- New `matchesKey` cases for three-part chords, including rejection when a named modifier is missing or an extra one is held.
- The parity spec gained three-part entries, so the two implementations are held to agreeing on chords as well as single keys.

534 passing. Also exercised the **built** `app/preloadKeys.js`, since it ships unbundled:

```
convertSettingsKey("Control+Shift+a") -> Control+Shift+KeyA
  matched by Ctrl+Shift+A     -> true   (want true)
  matched by Shift+A only     -> false  (want false)
  matched by Ctrl+Shift+Alt+A -> false  (want false)
```

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)