### PR TITLE
fix(settings): restore the default for a missing remote key instead of throwing

### DIFF
--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -1092,43 +1092,46 @@ export function getSettings(window) {
 }
 
 export function setRemoteKeys(defaults, remote) {
+    // Each key is restored to its default when it is missing, not just when it is empty:
+    // a settings file from an older build can omit one entirely, and convertKey would
+    // throw on the nullish value from inside the settings-save handler.
     const customKeys = new Map();
-    if (remote.keyBack === "") {
+    if (!remote.keyBack) {
         settings.value("remote.keyBack", defaults.keyBack);
     } else if (defaults.keyBack !== remote.keyBack) {
         customKeys.set(convertKey(remote.keyBack), "back");
     }
-    if (remote.keyHome === "") {
+    if (!remote.keyHome) {
         settings.value("remote.keyHome", defaults.keyHome);
     } else if (defaults.keyHome !== remote.keyHome) {
         customKeys.set(convertKey(remote.keyHome), "home");
     }
-    if (remote.keyInfo === "") {
+    if (!remote.keyInfo) {
         settings.value("remote.keyInfo", defaults.keyInfo);
     } else if (defaults.keyInfo !== remote.keyInfo) {
         customKeys.set(convertKey(remote.keyInfo), "info");
     }
-    if (remote.keyReplay === "") {
+    if (!remote.keyReplay) {
         settings.value("remote.keyReplay", defaults.keyReplay);
     } else if (defaults.keyReplay !== remote.keyReplay) {
         customKeys.set(convertKey(remote.keyReplay), "instantreplay");
     }
-    if (remote.keyPlayPause === "") {
+    if (!remote.keyPlayPause) {
         settings.value("remote.keyPlayPause", defaults.keyPlayPause);
     } else if (defaults.keyPlayPause !== remote.keyPlayPause) {
         customKeys.set(convertKey(remote.keyPlayPause), "play");
     }
-    if (remote.keyRev === "") {
+    if (!remote.keyRev) {
         settings.value("remote.keyRev", defaults.keyRev);
     } else if (defaults.keyRev !== remote.keyRev) {
         customKeys.set(convertKey(remote.keyRev), "rev");
     }
-    if (remote.keyFwd === "") {
+    if (!remote.keyFwd) {
         settings.value("remote.keyFwd", defaults.keyFwd);
     } else if (defaults.keyFwd !== remote.keyFwd) {
         customKeys.set(convertKey(remote.keyFwd), "fwd");
     }
-    if (remote.keyMute === "") {
+    if (!remote.keyMute) {
         settings.value("remote.keyMute", defaults.keyMute);
     } else if (defaults.keyMute !== remote.keyMute) {
         customKeys.set(convertKey(remote.keyMute), "volumemute");

--- a/test/unit/helpers/settings-remoteKeys.spec.js
+++ b/test/unit/helpers/settings-remoteKeys.spec.js
@@ -1,0 +1,71 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Simulation Desktop Application (https://github.com/lvcabral/brs-desktop)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { describe, it, expect, beforeEach } from "vitest";
+import { createFakeWindow, __registerWindow } from "../../mocks/electron.js";
+import { getSettings, setRemoteKeys } from "../../../src/helpers/settings";
+
+const DEFAULTS = {
+    keyBack: "Escape",
+    keyHome: "Home",
+    keyInfo: "Insert",
+    keyReplay: "Backspace",
+    keyPlayPause: "End",
+    keyRev: "PageUp",
+    keyFwd: "PageDown",
+    keyMute: "F10",
+};
+
+describe("setRemoteKeys", () => {
+    let win;
+    let settings;
+
+    beforeEach(() => {
+        win = __registerWindow(createFakeWindow(1));
+        settings = getSettings(win);
+    });
+
+    /**
+     * Read the custom key map pushed to the renderer, if any
+     * @returns {Map|undefined} - The map sent on the setCustomKeys channel
+     */
+    function sentCustomKeys() {
+        return win.sentOn("setCustomKeys")[0]?.args[0];
+    }
+
+    it("pushes only the keys that differ from the defaults", () => {
+        setRemoteKeys(DEFAULTS, { ...DEFAULTS, keyHome: "F1" });
+        expect([...sentCustomKeys().entries()]).toEqual([["F1", "home"]]);
+    });
+
+    it("sends nothing when every key is at its default", () => {
+        setRemoteKeys(DEFAULTS, { ...DEFAULTS });
+        expect(win.sentOn("setCustomKeys")).toHaveLength(0);
+    });
+
+    it("restores the default for a cleared key", () => {
+        setRemoteKeys(DEFAULTS, { ...DEFAULTS, keyMute: "" });
+        expect(settings.value("remote.keyMute")).toBe("F10");
+    });
+
+    // A settings file written by an older build, or edited by hand, can be missing a remote
+    // key entirely. Only `=== ""` was guarded, so a nullish value reached convertKey, which
+    // calls .replaceAll on it — an exception thrown inside the settings-save IPC handler.
+    it.each([
+        ["undefined", undefined],
+        ["null", null],
+    ])("restores the default for a %s key instead of throwing", (_label, value) => {
+        expect(() => setRemoteKeys(DEFAULTS, { ...DEFAULTS, keyInfo: value })).not.toThrow();
+        expect(settings.value("remote.keyInfo")).toBe("Insert");
+    });
+
+    it("survives a settings object missing every remote key", () => {
+        expect(() => setRemoteKeys(DEFAULTS, {})).not.toThrow();
+        expect(settings.value("remote.keyBack")).toBe("Escape");
+        expect(settings.value("remote.keyMute")).toBe("F10");
+    });
+});


### PR DESCRIPTION
## Problem

`setRemoteKeys` guarded each of the eight remote-key preferences with `=== ""`:

```js
if (remote.keyBack === "") {
    settings.value("remote.keyBack", defaults.keyBack);   // restore default
} else if (defaults.keyBack !== remote.keyBack) {
    customKeys.set(convertKey(remote.keyBack), "back");   // nullish lands here
}
```

Only an *explicitly cleared* key took the restore path. A settings file written by an older build, or edited by hand, can omit a key entirely — and that nullish value reached `convertKey`, which calls `.replaceAll` on it:

```
TypeError: Cannot read properties of undefined (reading 'replaceAll')
```

Thrown inside the settings-save IPC handler, on the main process.

Pinned indirectly by `test/unit/app/preloadKeys.parity.spec.js` in #296, which asserted `expect(() => convertKey(null)).toThrow()` and labelled the divergence "intentional" — it wasn't; only the preload half had a guard.

## Fix

Each guard now tests for truthiness, so missing, `null` and `""` all restore the default. Nothing else changes: a key equal to its default is still skipped, a key that differs is still converted and broadcast.

Defaulting to `"Home"` the way the preload does would be wrong here — these are eight distinct actions with eight distinct defaults.

## Tests

`setRemoteKeys` had **no coverage at all** before this. New `test/unit/helpers/settings-remoteKeys.spec.js` covers the happy path, the cleared-key path, both nullish shapes, and a settings object missing every key. Confirmed failing before the change with the `TypeError` above.

536 passing; both webpack configs compile.

### Noted, not done

The eight blocks are near-identical and would collapse to a short table-driven loop. Left alone to keep this diff to the defect — happy to follow up.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)