### PR TITLE
fix(roku): detect a compile failure regardless of whitespace

### DIFF
--- a/src/helpers/roku.js
+++ b/src/helpers/roku.js
@@ -261,5 +261,7 @@ async function postInstallerRequest(device, path, formData, callback) {
 
 // Helper function to check for compilation error in response body
 export function isCompileError(responseHtml) {
-    return !!/install\sfailure:\scompilation\sfailed/i.exec(responseHtml);
+    // \s+ rather than \s: the phrase is embedded in an HTML page whose whitespace and line
+    // wrapping vary between Roku firmware versions, so a single-space match is too strict.
+    return !!/install\s+failure:\s+compilation\s+failed/i.exec(responseHtml);
 }

--- a/test/unit/helpers/roku-response.spec.js
+++ b/test/unit/helpers/roku-response.spec.js
@@ -25,11 +25,11 @@ describe("isCompileError", () => {
         expect(isCompileError("Install\tFailure:\nCompilation Failed")).toBe(true);
     });
 
-    // Characterization: the pattern uses \s rather than \s+, so it matches exactly one
-    // whitespace character between words. Doubled spacing slips past the check and the
-    // failure is reported as a generic install error instead of a compile error.
-    it("does not match when the words are separated by more than one space", () => {
-        expect(isCompileError("Install Failure:  Compilation Failed")).toBe(false);
+    it("tolerates any run of whitespace between the words", () => {
+        expect(isCompileError("Install Failure:  Compilation Failed")).toBe(true);
+        expect(isCompileError("Install  Failure:\n\n  Compilation\tFailed")).toBe(true);
+        // Real pages wrap the text in markup, so the spacing is not under our control.
+        expect(isCompileError("<font color=\"red\">Install Failure:\n    Compilation Failed</font>")).toBe(true);
     });
 
     it("returns false for a successful install", () => {


### PR DESCRIPTION
## Problem

```js
return !!/install\sfailure:\scompilation\sfailed/i.exec(responseHtml);
```

`\s` matches **exactly one** whitespace character. The phrase is embedded in an HTML page served by the peer Roku, whose spacing and line wrapping vary between firmware versions, so a page that wrapped the text — or simply used two spaces — slipped past the check.

When it slips past, `runOnPeerRoku` reports the generic `Response Installing app: <status>` instead of `Error compiling app: <status> check telnet console for details` — pointing the user *away* from the console output that actually explains the failure.

Pinned by `test/unit/helpers/roku-response.spec.js` in #296 as *"does not match when the words are separated by more than one space"*.

## Fix

`\s` → `\s+`.

## Tests

The pinned test inverts to `toBe(true)` and gains a newline/tab case and a realistic markup-wrapped case. Confirmed failing before the change. 530 passing.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)