### PR TITLE
fix(updates): read the numeric prefix of a version segment

### DIFF
--- a/src/helpers/version.js
+++ b/src/helpers/version.js
@@ -12,9 +12,24 @@
  * @param {string} latest - The version to compare against
  * @returns {number} - 1 when latest is newer, -1 when current is newer, 0 when equal
  */
+/**
+ * Split a version into numeric segments, ignoring any suffix on each one
+ * @param {string} version - The version string, with or without a leading "v"
+ * @returns {number[]} - The numeric segments
+ */
+function toSegments(version) {
+    // parseInt rather than Number so a pre-release suffix reads as its release number:
+    // Number("1-beta") is NaN, which the `|| 0` below would collapse to zero, making
+    // 2.3.1-beta compare equal to 2.3.0.
+    return version
+        .replace("v", "")
+        .split(".")
+        .map((segment) => Number.parseInt(segment, 10));
+}
+
 export function compareVersions(current, latest) {
-    const currentParts = current.replace("v", "").split(".").map(Number);
-    const latestParts = latest.replace("v", "").split(".").map(Number);
+    const currentParts = toSegments(current);
+    const latestParts = toSegments(latest);
 
     for (let i = 0; i < Math.max(currentParts.length, latestParts.length); i++) {
         const currentPart = currentParts[i] || 0;

--- a/test/unit/helpers/version.spec.js
+++ b/test/unit/helpers/version.spec.js
@@ -50,11 +50,24 @@ describe("compareVersions", () => {
         expect(compareVersions("3.0.0", "2.99.99")).toBe(-1);
     });
 
-    // Characterization: segments are parsed with Number(), so a pre-release suffix becomes
-    // NaN and the `|| 0` fallback treats it as zero. "2.3.1-beta" therefore compares equal
-    // to "2.3.0", and the user is never told about a pre-release.
-    it("treats a non-numeric segment as zero", () => {
-        expect(compareVersions("2.3.0", "2.3.1-beta")).toBe(0);
+    it("reads the numeric prefix of a segment with a suffix", () => {
+        // 2.3.1-beta is release 2.3.1 as far as ordering goes; the suffix is ignored rather
+        // than collapsing the whole segment to zero.
+        expect(compareVersions("2.3.0", "2.3.1-beta")).toBe(1);
+        expect(compareVersions("2.3.1-beta", "2.3.0")).toBe(-1);
+    });
+
+    it("treats a pre-release of the same version as that version", () => {
+        // Deliberate: the updater offers stable releases, so 2.3.0-alpha is not "newer"
+        // than 2.3.0 and does not trigger a notification.
         expect(compareVersions("2.3.0-alpha", "2.3.0")).toBe(0);
+        expect(compareVersions("2.3.0", "2.3.0-rc1")).toBe(0);
+    });
+
+    it("does not offer an unparseable version as an update", () => {
+        // Guard, not a fix: an unparseable segment already falls back to zero, so a
+        // malformed tag reads as older and never triggers a notification.
+        expect(compareVersions("2.3.0", "garbage")).toBe(-1);
+        expect(compareVersions("2.3.0", "")).toBe(-1);
     });
 });


### PR DESCRIPTION
## Problem

`compareVersions` parsed each dotted segment with `Number()`:

```js
const currentParts = current.replace("v", "").split(".").map(Number);
...
const latestPart = latestParts[i] || 0;
```

`Number("1-beta")` is `NaN`, and `|| 0` collapses it to zero. So **`2.3.1-beta` read as `2.3.0`** and compared equal to it — a user on 2.3.0 was never told 2.3.1 exists once the tag carried any suffix.

Pinned by `test/unit/helpers/version.spec.js` in #296 as *"treats a non-numeric segment as zero"*.

## Fix

Parse segments with `parseInt`, which reads the leading number and ignores the rest.

Per the decision on this series, a pre-release of the **same** version still compares equal, so the updater keeps offering stable releases only — `2.3.0-alpha` does not prompt someone already on `2.3.0`.

## A correction to the plan

The plan claimed a garbage version "compares equal to everything, suppressing the prompt". Verifying that, it turned out to be **wrong**: `Number("garbage")` is `NaN`, `|| 0` makes it `0`, and zero reads as *older* — so `compareVersions("2.3.0", "garbage")` already returned `-1` and never triggered a prompt.

That case is now covered as a regression guard rather than presented as a fix, and the test comment says so.

## Tests

- The pinned test becomes two: suffixed segments order by their number, and a pre-release of the same version stays equal.
- A guard for unparseable versions.

532 passing; confirmed the prefix test failed before the change.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)