### PR TITLE
fix(cli): stop a bare -w persisting NaN as the web installer port

### DIFF
--- a/src/cliArgs.js
+++ b/src/cliArgs.js
@@ -9,7 +9,9 @@
 // minimist configuration for the command line documented in docs/how-to-use.md.
 // Extracted from main.js, which has no exports and performs Electron work at module scope.
 export const cliArgumentsConfig = {
-    string: ["o", "p", "m"],
+    // `w` belongs here with the other value-taking options: left undeclared, minimist
+    // infers the type, so a bare `-w` becomes boolean true and `-w 8080` a number.
+    string: ["o", "p", "m", "w"],
     boolean: ["c", "d", "e", "f", "r"],
     alias: {
         c: "console",

--- a/src/main.js
+++ b/src/main.js
@@ -356,8 +356,13 @@ function processArgv(mainWindow, startup = {}, cliArgs = argv, options = {}) {
         settings.value("services.password", cliArgs.pwd.trim());
     }
     if (cliArgs?.web) {
+        const webPort = Number.parseInt(cliArgs.web, 10);
         setPort(cliArgs.web);
-        settings.value("services.webPort", Number.parseInt(cliArgs.web));
+        // Only persist a port that actually parsed: writing NaN into the settings file
+        // would leave the web installer unable to start on the next launch.
+        if (!Number.isNaN(webPort)) {
+            settings.value("services.webPort", webPort);
+        }
         enableInstaller(mainWindow);
     } else if (applyStartup && startupOptions.installerEnabled) {
         enableInstaller(mainWindow);

--- a/test/unit/cliArgs.spec.js
+++ b/test/unit/cliArgs.spec.js
@@ -77,15 +77,12 @@ describe("string options", () => {
         expect(parse("-o", "/tmp/channel.zip").o).toBe("/tmp/channel.zip");
     });
 
-    // Characterization: `w` is aliased but declared in neither `string` nor `boolean`, so
-    // minimist infers the type and a numeric port arrives as a number. processArgv() in
-    // main.js runs it through Number.parseInt anyway, which absorbs either shape.
-    it("infers the type of the web port", () => {
-        expect(parse("-w", "8080").web).toBe(8080);
-        expect(typeof parse("-w", "8080").web).toBe("number");
-        // With no value minimist infers a flag, so a bare -w is boolean true rather than
-        // an empty string. main.js guards this by parsing the value defensively.
-        expect(parse("-w").web).toBe(true);
+    it("keeps the web port a string, like the other value-taking options", () => {
+        // Declared as a string so a bare -w yields "" rather than boolean true, which
+        // would otherwise be persisted to services.webPort as NaN.
+        expect(parse("-w", "8080").web).toBe("8080");
+        expect(typeof parse("-w", "8080").web).toBe("string");
+        expect(parse("-w").web).toBe("");
     });
 });
 


### PR DESCRIPTION
## Problem

`w` was aliased in `src/cliArgs.js` but declared in neither `string` nor `boolean`, so minimist inferred the type per invocation:

| invocation | `cliArgs.web` |
| --- | --- |
| `-w 8080` | `8080` (number) |
| `-w` | `true` (boolean) |

`main.js` then ran `Number.parseInt(true)` → **`NaN`** and wrote it to `services.webPort`, leaving a port the web installer cannot bind on the next launch.

Pinned by `test/unit/cliArgs.spec.js` in #296 as *"infers the type of the web port"*.

## Fix

Two parts:

1. **`src/cliArgs.js`** — declare `w` alongside `o`, `p` and `m`. A bare `-w` now yields `""`, which is falsy, so the branch is skipped entirely.
2. **`src/main.js`** — skip the settings write when the value doesn't parse. This also covers `-w abc`, which the first change alone wouldn't.

`setPort` already ignored a non-numeric argument, so only the persisted setting was ever affected — narrower than the pinning comment claimed, and the commit says so.

## Tests

The pinned test now asserts the string type and `""` for a bare flag. Confirmed failing before the change. 530 passing; both webpack configs compile.

> `src/main.js` uses CRLF line endings; the edit preserves them, so the diff is 6 lines rather than the whole file.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)