### PR TITLE
fix(util): return nothing for firmware outside the version alphabet

### DIFF
--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -229,6 +229,12 @@ export function getRokuOS(firmware, version = true, full = false) {
         }
         const versions = "0123456789ACDEFGHJKLMNPRSTUVWXY";
         const major = versions.indexOf(firmware.charAt(2));
+        if (major < 0) {
+            // Not a character this encoding uses (B, I, O, Q and Z are excluded to avoid
+            // digit lookalikes). Report nothing, as for firmware too short to decode,
+            // rather than a negative major version in the ECP XML and telnet banner.
+            return "";
+        }
         const minor = firmware.slice(4, 5);
         const revision = firmware.slice(5, 6);
         const base = `${major}.${minor}.${revision}`;

--- a/test/unit/helpers/util.spec.js
+++ b/test/unit/helpers/util.spec.js
@@ -137,10 +137,18 @@ describe("getRokuOS", () => {
         expect(getRokuOS(null)).toBe("");
     });
 
-    // Characterization: a character outside the alphabet yields indexOf() === -1 rather
-    // than an error or a fallback, so the major version comes back negative.
-    it("reports a negative major version for an unknown alphabet character", () => {
-        expect(getRokuOS("XXB.30E04170A")).toBe("-1.3.0");
+    it("returns an empty string for a character outside the version alphabet", () => {
+        // B, I, O, Q and Z are deliberately absent from the alphabet. Treat an
+        // unrecognised character the same as firmware that is too short to decode,
+        // rather than reporting a negative major version.
+        expect(getRokuOS("XXB.30E04170A")).toBe("");
+        expect(getRokuOS("XXZ.30E04170A")).toBe("");
+        expect(getRokuOS("XXB.30E04170A", true, true)).toBe("");
+    });
+
+    it("still returns the build for an unknown character when asked for the build", () => {
+        // The build is a plain slice and does not depend on the alphabet.
+        expect(getRokuOS("XXB.30E04170A", false)).toBe("4170");
     });
 });
 


### PR DESCRIPTION
## Problem

`getRokuOS` decodes the major version by looking the third character up in `"0123456789ACDEFGHJKLMNPRSTUVWXY"` — `B`, `I`, `O`, `Q` and `Z` are deliberately excluded to avoid digit lookalikes.

`indexOf` was used unguarded, so an unrecognised character yielded `-1`:

```js
getRokuOS("XXB.30E04170A")  ->  "-1.3.0"
```

That value reaches the ECP `<software-version>` element and the telnet banner, where a client parsing it as a version could misbehave.

Pinned by `test/unit/helpers/util.spec.js` in #296 as *"reports a negative major version for an unknown alphabet character"*.

## Fix

Return `""` for an unknown character — matching what the function already does for firmware too short to decode. Requesting the *build* still works, since that's a plain slice independent of the alphabet.

## Tests

The pinned test now expects `""`, with a second excluded character and the `full` variant covered, plus a test confirming the build is still returned. Confirmed failing before the change. 531 passing.

Reachable only with a hand-edited or corrupted firmware string — app-generated firmware always uses alphabet characters — so this is a robustness fix rather than a live defect.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)