### PR TITLE
fix(util): reject malformed IP addresses instead of coercing them

### DIFF
--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -26,8 +26,14 @@ export function isValidIP(ip) {
     return (
         parts.length === 4 &&
         parts.every((part) => {
+            // Match the digits explicitly before the range check. Number() alone accepts
+            // "" as 0, " 1" as 1, "0x10" as 16 and "4e0" as 4, so malformed addresses
+            // passed validation and only failed later as an opaque network error.
+            if (!/^\d{1,3}$/.test(part)) {
+                return false;
+            }
             const num = Number(part);
-            return !Number.isNaN(num) && num >= 0 && num <= 255;
+            return num >= 0 && num <= 255;
         })
     );
 }

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -229,6 +229,12 @@ export function getRokuOS(firmware, version = true, full = false) {
         }
         const versions = "0123456789ACDEFGHJKLMNPRSTUVWXY";
         const major = versions.indexOf(firmware.charAt(2));
+        if (major < 0) {
+            // Not a character this encoding uses (B, I, O, Q and Z are excluded to avoid
+            // digit lookalikes). Report nothing, as for firmware too short to decode,
+            // rather than a negative major version in the ECP XML and telnet banner.
+            return "";
+        }
         const minor = firmware.slice(4, 5);
         const revision = firmware.slice(5, 6);
         const base = `${major}.${minor}.${revision}`;

--- a/test/unit/helpers/util.spec.js
+++ b/test/unit/helpers/util.spec.js
@@ -52,14 +52,23 @@ describe("isValidIP", () => {
         expect(isValidIP(["1.2.3.4"])).toBe(false);
     });
 
-    // The implementation coerces each octet with Number(), which is more permissive than a
-    // strict parser. These are characterization tests: they pin what the function does today
-    // so a future tightening is a deliberate, visible change.
-    it("accepts inputs a strict parser would reject", () => {
-        expect(isValidIP("1.2.3.")).toBe(true); // Number("") === 0
-        expect(isValidIP(" 1.2.3.4")).toBe(true); // Number(" 1") === 1
-        expect(isValidIP("0x10.1.1.1")).toBe(true); // Number("0x10") === 16
-        expect(isValidIP("1.2.3.4e0")).toBe(true); // Number("4e0") === 4
+    it("rejects octets that are not plain decimal numbers", () => {
+        // Number() coercion used to accept all of these: "" is 0, " 1" is 1, "0x10" is 16
+        // and "4e0" is 4. A configured peer address that looks like one of these is a
+        // typo, and failing here beats a confusing network error later.
+        expect(isValidIP("1.2.3.")).toBe(false);
+        expect(isValidIP(" 1.2.3.4")).toBe(false);
+        expect(isValidIP("0x10.1.1.1")).toBe(false);
+        expect(isValidIP("1.2.3.4e0")).toBe(false);
+        expect(isValidIP("1.2.3.+4")).toBe(false);
+        expect(isValidIP("1.2.3.0004")).toBe(false);
+    });
+
+    it("still accepts ordinary addresses", () => {
+        // Guard against over-tightening: leading zeros within three digits are common in
+        // hand-typed addresses and remain acceptable.
+        expect(isValidIP("192.168.001.1")).toBe(true);
+        expect(isValidIP("010.0.0.1")).toBe(true);
     });
 });
 

--- a/test/unit/helpers/util.spec.js
+++ b/test/unit/helpers/util.spec.js
@@ -137,10 +137,18 @@ describe("getRokuOS", () => {
         expect(getRokuOS(null)).toBe("");
     });
 
-    // Characterization: a character outside the alphabet yields indexOf() === -1 rather
-    // than an error or a fallback, so the major version comes back negative.
-    it("reports a negative major version for an unknown alphabet character", () => {
-        expect(getRokuOS("XXB.30E04170A")).toBe("-1.3.0");
+    it("returns an empty string for a character outside the version alphabet", () => {
+        // B, I, O, Q and Z are deliberately absent from the alphabet. Treat an
+        // unrecognised character the same as firmware that is too short to decode,
+        // rather than reporting a negative major version.
+        expect(getRokuOS("XXB.30E04170A")).toBe("");
+        expect(getRokuOS("XXZ.30E04170A")).toBe("");
+        expect(getRokuOS("XXB.30E04170A", true, true)).toBe("");
+    });
+
+    it("still returns the build for an unknown character when asked for the build", () => {
+        // The build is a plain slice and does not depend on the alphabet.
+        expect(getRokuOS("XXB.30E04170A", false)).toBe("4170");
     });
 });
 


### PR DESCRIPTION
> **Stacked on #304** — base is `fix/rokuos-unknown-char`, not `master`, because both touch `src/helpers/util.js`. Merge that one first and this retargets automatically.

## Problem

`isValidIP` coerced each octet with `Number()`, which is far looser than it looks:

| input | why it passed |
| --- | --- |
| `"1.2.3."` | `Number("")` is `0` |
| `" 1.2.3.4"` | `Number(" 1")` is `1` |
| `"0x10.1.1.1"` | `Number("0x10")` is `16` |
| `"1.2.3.4e0"` | `Number("4e0")` is `4` |

The guard exists so a mistyped peer Roku address is caught at configuration time. Accepting these meant the typo survived and surfaced later as an opaque `fetch` failure with no hint that the address was the problem.

Pinned by `test/unit/helpers/util.spec.js` in #296 as *"accepts inputs a strict parser would reject"*.

## Fix

Each octet must match `/^\d{1,3}$/` before the existing 0–255 range check.

Leading zeros within three digits (`192.168.001.1`) still pass — common in hand-typed addresses and unambiguous — and there's a test pinning that, so the tightening doesn't quietly go further than intended.

## Blast radius

Callers are `runOnPeerRoku` / the `currentApp` handler in `src/helpers/roku.js` (peer deploy) and `sendInput` in `src/server/ecp.js`, where the value comes from `req.socket.remoteAddress` and is never malformed.

**A previously-stored malformed peer IP will now fail validation** — which is the intent, but it means someone with a typo'd address saved will start seeing the "Invalid peer Roku IP address" message instead of a network error. That's the improvement, stated plainly in case it looks like a regression.

## Tests

The pinned test flips to `toBe(false)` and gains `+4` and `0004` cases; a new test guards against over-tightening. Confirmed failing before the change.

532 passing — including the ECP integration test that runs `isValidIP` against a real socket address, so the `::ffff:` normalisation path is still exercised.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)