### PR TITLE
fix(hash): return a string from hashCode for every input

### DIFF
--- a/src/helpers/hash.js
+++ b/src/helpers/hash.js
@@ -9,7 +9,8 @@
 // Generate short Hash
 String.prototype.hashCode = function () {
     let hash = 0;
-    if (this.length === 0) return hash;
+    // Falls through to the shared return below rather than yielding a number here: every
+    // caller uses the result to build a filename, so the type has to be consistent.
     for (let i = 0; i < this.length; i++) {
         const chr = this.charCodeAt(i);
         hash = (hash << 5) - hash + chr;

--- a/test/unit/helpers/hash.spec.js
+++ b/test/unit/helpers/hash.spec.js
@@ -38,13 +38,18 @@ describe("String.prototype.hashCode", () => {
         expect("日本語.zip".hashCode()).toMatch(/^\d+$/);
     });
 
-    // Characterization: the empty-string early return yields the *number* 0, while every
-    // other input goes through Math.abs(hash).toString() and yields a string. Callers use
-    // the result to build filenames (see genAppRegistry in src/server/ecp.js), where the
-    // implicit coercion hides the inconsistency.
-    it("returns the number 0 for an empty string, not the string \"0\"", () => {
-        expect("".hashCode()).toBe(0);
-        expect(typeof "".hashCode()).toBe("number");
+    it("returns a string for the empty string, like every other input", () => {
+        // The early return used to yield the number 0 while every other input went
+        // through Math.abs(hash).toString(). Callers build filenames from the result,
+        // so implicit coercion hid the inconsistency rather than removing it.
+        expect("".hashCode()).toBe("0");
+        expect(typeof "".hashCode()).toBe("string");
+    });
+
+    it("returns a string for every input", () => {
+        for (const sample of ["", "a", "/tmp/x.zip", "\u{1F600}"]) {
+            expect(typeof sample.hashCode()).toBe("string");
+        }
     });
 
     it("never returns a negative value", () => {


### PR DESCRIPTION
## Problem

```js
let hash = 0;
if (this.length === 0) return hash;   // number
...
return Math.abs(hash).toString();     // string
```

The empty-string early return yielded the **number** `0`; every other input yielded a **string**.

Callers build filenames from the result — the app registry payload in `src/server/ecp.js`, recent-file icons in `src/menu/menuService.js`, the editor's `saveIcon` id — so implicit coercion hid the inconsistency rather than removing it. Any strict comparison or `typeof` check would have tripped over it.

Pinned by `test/unit/helpers/hash.spec.js` in #296 as *"returns the number 0 for an empty string, not the string \"0\""*.

## Fix

Dropping the early return is sufficient: an empty string leaves the loop body unexecuted, so `hash` stays `0` and the shared return produces `"0"`. **No hash value changes for any other input** — the loop is untouched.

## Tests

The pinned test now expects `"0"` / `"string"`, plus a test asserting the return type across a range of inputs including an emoji. Confirmed failing before the change. 531 passing, with the existing known-value and stability tests unchanged.

Not reachable today — every caller passes a non-empty path — so this is a type-consistency fix rather than a live defect.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)