### PR TITLE
fix(statusbar): keep the shortened path within its budget

### DIFF
--- a/src/app/statusbarUtils.js
+++ b/src/app/statusbarUtils.js
@@ -17,25 +17,52 @@
  * @returns {string} - The shortened path, or the original when it already fits
  */
 export function shortenPath(bigPath, maxLen) {
-    let path = bigPath;
-    if (path.length > maxLen) {
-        const splitter = bigPath.includes("/") ? "/" : "\\";
-        const tokens = bigPath.split(splitter);
-        const drive = bigPath.includes(":") ? tokens[0] : "";
-        const fileName = tokens.at(-1);
-        const len = drive.length + fileName.length;
-        const remLen = maxLen - len - 3; // remove the current length and also space for ellipsis char and 2 slashes
-        //remove first and last elements from the array
-        tokens.splice(0, 1);
-        tokens.splice(-1, 1);
-        //recreate our path
-        path = tokens.join(splitter);
-        //rebuild the path from beginning and end
-        const pathA = path.substring(0, Math.ceil(remLen / 2));
-        const pathB = path.substring(path.length - Math.floor(remLen / 2));
-        path = `${drive}${splitter}${pathA}…${pathB}${splitter}${fileName}`;
+    if (bigPath.length <= maxLen) {
+        return bigPath;
     }
-    return path;
+    const splitter = bigPath.includes("/") ? "/" : "\\";
+    const tokens = bigPath.split(splitter);
+    const fileName = tokens.at(-1);
+
+    // Nothing to elide between the drive and the filename, so shorten the name itself
+    // rather than inventing separators the original path never had.
+    if (tokens.length < 3) {
+        return elide(fileName, maxLen);
+    }
+
+    const drive = bigPath.includes(":") ? tokens[0] : "";
+    // Budget for the directories: the total, less the drive, the filename, the ellipsis
+    // and the two separators around it. Clamped, because the filename alone can exceed it.
+    const remLen = Math.max(0, maxLen - drive.length - fileName.length - 3);
+    if (remLen === 0) {
+        // No room for any directory context; keep the filename, elided if need be.
+        return elide(fileName, maxLen);
+    }
+
+    const middle = tokens.slice(1, -1).join(splitter);
+    const head = middle.substring(0, Math.ceil(remLen / 2));
+    const tail = middle.substring(middle.length - Math.floor(remLen / 2));
+    return `${drive}${splitter}${head}…${tail}${splitter}${fileName}`;
+}
+
+/**
+ * Shorten a single name to fit, eliding its middle
+ * @param {string} name - The name to shorten
+ * @param {number} maxLen - The maximum length
+ * @returns {string} - The name, no longer than maxLen
+ */
+function elide(name, maxLen) {
+    if (name.length <= maxLen) {
+        return name;
+    }
+    if (maxLen <= 1) {
+        return name.substring(0, Math.max(0, maxLen));
+    }
+    // Keep the extension visible: it is the part that identifies the file type.
+    const keep = maxLen - 1;
+    const head = Math.ceil(keep / 2);
+    const tail = Math.floor(keep / 2);
+    return `${name.substring(0, head)}…${tail > 0 ? name.substring(name.length - tail) : ""}`;
 }
 
 /**

--- a/test/unit/app/__snapshots__/statusbarUtils.spec.js.snap
+++ b/test/unit/app/__snapshots__/statusbarUtils.spec.js.snap
@@ -1,5 +1,5 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`shortenPath > can exceed maxLen when the filename is longer than the budget 1`] = `"/…/a-very-long-channel-filename-indeed.zip"`;
+exports[`shortenPath > leaves a bare filename alone rather than injecting separators 1`] = `"averyveryv…ashes.zip"`;
 
-exports[`shortenPath > handles a path with no directory component 1`] = `"\\…\\averyveryverylongfilenamewithnoslashes.zip"`;
+exports[`shortenPath > never exceeds maxLen, even when the filename alone is longer 1`] = `"a-very-long-cha…ame-indeed.zip"`;

--- a/test/unit/app/statusbarUtils.spec.js
+++ b/test/unit/app/statusbarUtils.spec.js
@@ -56,19 +56,37 @@ describe("shortenPath", () => {
         expect(windows).not.toContain("/");
     });
 
-    // Characterization: when the filename alone nearly fills maxLen, remLen goes negative.
-    // substring() then receives inverted or negative arguments, and the result can come
-    // back *longer* than maxLen. The status bar is cosmetic so this is pinned, not fixed —
-    // the right behaviour (truncate the filename? show only the basename?) is a UI decision.
-    it("can exceed maxLen when the filename is longer than the budget", () => {
+    it("never exceeds maxLen, even when the filename alone is longer", () => {
+        // remLen used to go negative here, handing substring() inverted arguments and
+        // producing a result longer than the budget it was asked to fit.
         const path = "/Users/test/Documents/a-very-long-channel-filename-indeed.zip";
         const maxLen = 30;
         const result = shortenPath(path, maxLen);
-        expect(result.length).toBeGreaterThan(maxLen);
+        expect(result.length).toBeLessThanOrEqual(maxLen);
         expect(result).toMatchSnapshot();
     });
 
-    it("handles a path with no directory component", () => {
-        expect(shortenPath("averyveryverylongfilenamewithnoslashes.zip", 10)).toMatchSnapshot();
+    it("never exceeds maxLen across a range of budgets", () => {
+        const paths = [
+            "/Users/test/Documents/Projects/BrightScript/channels/mychannel.zip",
+            "/Users/test/Documents/a-very-long-channel-filename-indeed.zip",
+            "C:\\Users\\test\\Documents\\Projects\\a-long-name.zip",
+            "averyveryverylongfilenamewithnoslashes.zip",
+        ];
+        for (const path of paths) {
+            for (let maxLen = 8; maxLen <= 60; maxLen++) {
+                expect(shortenPath(path, maxLen).length).toBeLessThanOrEqual(maxLen);
+            }
+        }
+    });
+
+    it("leaves a bare filename alone rather than injecting separators", () => {
+        // There is no directory to elide, so the old code inserted backslashes into a
+        // name that never contained any.
+        const bare = "averyveryverylongfilenamewithnoslashes.zip";
+        const result = shortenPath(bare, 20);
+        expect(result).not.toContain("\\");
+        expect(result.length).toBeLessThanOrEqual(20);
+        expect(result).toMatchSnapshot();
     });
 });


### PR DESCRIPTION
## Problem

`shortenPath` computed the directory budget without clamping:

```js
const remLen = maxLen - len - 3;                                      // can go negative
const pathA = path.substring(0, Math.ceil(remLen / 2));               // negative -> ""
const pathB = path.substring(path.length - Math.floor(remLen / 2));   // index past end
```

When the filename alone exceeded the budget, `remLen` went negative, `substring` received inverted arguments, and the function returned a string **longer than the `maxLen` it was asked to fit** — overflowing the status bar on a narrow window.

Separately, a path containing no separator at all was still split on `\`, so the rebuild injected backslashes into a name that never had any — on every platform.

Both pinned in `test/unit/app/statusbarUtils.spec.js` by #296, the second one silently by snapshot alone.

## Fix

- Clamp the budget at zero.
- When there's no room for directory context, elide the **filename** instead, keeping the extension visible — it's the part that identifies the file.
- A path with no directory component is elided directly rather than reassembled around separators that don't exist.

```
maxLen=40 len=40  /Users/test/D…ipt/channels/mychannel.zip
maxLen=30 len=30  a-very-long-cha…ame-indeed.zip      <- was 41 chars
maxLen=20 len=20  averyveryv…ashes.zip                <- was "\…\averyvery..."
maxLen=40 len=40  C:\Users\test\…rightScript\mychannel.zip
```

## Tests

- The pinned overflow test becomes `toBeLessThanOrEqual`.
- A **property test** asserts the length contract across four shapes of path and every budget from 8 to 60 — the guarantee the function claims, rather than the three examples that happened to be sampled.
- The no-separator case gains an explicit assertion and comment; it was previously pinned by snapshot alone with no explanation.
- Both snapshots regenerated.

531 passing; both webpack configs compile.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)