### PR TITLE
refactor(menu): resolve recent-file menu items by id instead of position

### DIFF
--- a/src/menu/menuService.js
+++ b/src/menu/menuService.js
@@ -214,8 +214,13 @@ function rebuildMenu(template = false) {
     const appMenu = app.applicationMenu;
     if (isMacOS || template) {
         const recentMenu = menuTemplate[fileMenuIndex].submenu[recentMenuIndex].submenu;
+        // Look items up by id rather than by position. Indexing assumed the placeholder sat
+        // at exactly recentMenu[maxMenuFiles], so reordering the submenu or changing the
+        // entry count would silently set properties on undefined. The non-macOS branch
+        // below has always resolved these by id.
+        const findItem = (id) => recentMenu.find((item) => item.id === id);
         for (let index = 0; index < maxMenuFiles; index++) {
-            let fileMenu = recentMenu[index];
+            const fileMenu = findItem(`zip-${index}`);
             if (index < recentFiles.zip.length) {
                 fileMenu.label = recentFiles.zip[index];
                 fileMenu.visible = true;
@@ -223,8 +228,8 @@ function rebuildMenu(template = false) {
                 fileMenu.visible = false;
             }
         }
-        recentMenu[maxMenuFiles].visible = recentFiles.zip.length === 0;
-        recentMenu.at(-1).enabled = recentFiles.zip.length > 0;
+        findItem("zip-empty").visible = recentFiles.zip.length === 0;
+        findItem("file-clear").enabled = recentFiles.zip.length > 0;
         Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
         if (isMacOS && window) {
             if (appMenu.getMenuItemById("view-menu")) {

--- a/test/unit/menu/menuService-recent.spec.js
+++ b/test/unit/menu/menuService-recent.spec.js
@@ -9,7 +9,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { describe, it, expect, beforeEach } from "vitest";
 import { app, ipcMain, createFakeWindow, __registerWindow } from "../../mocks/electron.js";
-import { maxMenuFiles } from "../../../src/menu/fileMenuTemplate";
+import { fileMenuTemplate, maxMenuFiles } from "../../../src/menu/fileMenuTemplate";
 import { getSettings } from "../../../src/helpers/settings";
 import {
     createMenu,
@@ -188,12 +188,51 @@ describe("clearRecentFiles", () => {
     });
 });
 
-describe("recent-file limits", () => {
-    it("shows no more entries than the store keeps", () => {
-        // rebuildMenu() indexes recentMenu[maxMenuFiles] for the "empty" placeholder, so
-        // the menu length and the store cap are coupled: raising maxMenuFiles past the
-        // store size would index past the end of the generated submenu.
-        expect(maxMenuFiles).toBe(15);
-        expect(maxMenuFiles).toBeLessThanOrEqual(30);
+describe("recent-file menu", () => {
+    beforeEach(() => {
+        setupMenu();
+    });
+
+    /**
+     * The generated "Open Recent" submenu from the live template
+     * @returns {object[]} - The submenu items
+     */
+    function recentSubmenu() {
+        return fileMenuTemplate.submenu.find((item) => item.id === "file-open-recent").submenu;
+    }
+
+    it("generates one entry per menu slot plus the placeholder controls", () => {
+        const ids = recentSubmenu().map((item) => item.id ?? item.type);
+        for (let index = 0; index < maxMenuFiles; index++) {
+            expect(ids).toContain(`zip-${index}`);
+        }
+        expect(ids).toContain("zip-empty");
+        expect(ids).toContain("file-clear");
+    });
+
+    it("shows the placeholder only while the store is empty", () => {
+        const placeholder = () => recentSubmenu().find((item) => item.id === "zip-empty");
+        const clear = () => recentSubmenu().find((item) => item.id === "file-clear");
+        expect(placeholder().visible).toBe(true);
+        expect(clear().enabled).toBe(false);
+
+        addRecentPackage({ id: "1", path: "/tmp/one.zip", title: "One", version: "1.0.0" });
+        expect(placeholder().visible).toBe(false);
+        expect(clear().enabled).toBe(true);
+    });
+
+    it("shows at most maxMenuFiles entries however many are stored", () => {
+        // The store keeps more than the menu displays, so rebuilding with a full store
+        // must not run off the end of the generated submenu.
+        for (let index = 0; index < maxMenuFiles + 10; index++) {
+            addRecentPackage({
+                id: String(index),
+                path: `/tmp/app${index}.zip`,
+                title: `App ${index}`,
+                version: "1.0.0",
+            });
+        }
+        const visible = recentSubmenu().filter((item) => item.id?.startsWith("zip-") && item.visible);
+        expect(visible).toHaveLength(maxMenuFiles);
     });
 });


### PR DESCRIPTION
> **Hardening, not a live defect.** The current code works; the *test* guarding it was brittle. Flagged plainly so this isn't read as a bug fix.

## Problem

`rebuildMenu` reached into the "Open Recent" submenu positionally:

```js
let fileMenu = recentMenu[index];
recentMenu[maxMenuFiles].visible = recentFiles.zip.length === 0;   // placeholder
recentMenu.at(-1).enabled = recentFiles.zip.length > 0;            // clear command
```

This assumes the placeholder sits at exactly `recentMenu[maxMenuFiles]` and the clear command last. Reordering the submenu, or changing how many entries `buildRecentSubmenu` emits, would set properties on `undefined` during a menu rebuild.

The non-macOS branch of the same function has always resolved these by id — the two branches just disagreed.

## Fix

Resolve by id in both branches. **No behaviour change**: the current layout satisfies either form.

## The test was the real problem

The guard added in #296 pinned the constants themselves:

```js
expect(maxMenuFiles).toBe(15);
expect(maxMenuFiles).toBeLessThanOrEqual(30);
```

That red-fails on any legitimate menu-size change with no defect present, and never exercised the coupling it claimed to guard. Replaced with three behavioural tests:

- the submenu carries a slot per menu entry plus the placeholder controls
- the placeholder is visible only while the store is empty
- a store fuller than the menu still renders exactly `maxMenuFiles` entries

531 passing; both webpack configs compile.

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)