### PR TITLE
fix(ecp): resolve bundled assets so the routes work outside the bundle too

### DIFF
--- a/src/server/ecp.js
+++ b/src/server/ecp.js
@@ -14,6 +14,15 @@ import xmlbuilder from "xmlbuilder";
 import fs from "node:fs";
 import path from "node:path";
 
+// Bundled, this module lives at app/main.js so __dirname is app/, alongside the copied
+// images/ and web/ directories. Loaded directly from source -- by the tests -- __dirname
+// is src/server/ and the same assets sit in src/app/. Resolve once, preferring the
+// bundled layout, so both arrangements use one code path.
+const ASSET_BASE =
+    [__dirname, path.join(__dirname, "..", "app")].find((base) =>
+        fs.existsSync(path.join(base, "images"))
+    ) ?? __dirname;
+
 const WebSocket = require("ws");
 const url = require("node:url");
 const DEBUG = false;
@@ -259,13 +268,13 @@ function sendMediaPlayer(req, res) {
 }
 
 function sendDeviceImage(req, res) {
-    let image = fs.readFileSync(path.join(__dirname, "images", "device-image.png"));
+    let image = fs.readFileSync(path.join(ASSET_BASE, "images", "device-image.png"));
     res.setHeader("content-type", "image/png");
     res.send(image);
 }
 
 function sendScpdXML(req, res) {
-    let file = fs.readFileSync(path.join(__dirname, "web", "ecp_SCPD.xml"));
+    let file = fs.readFileSync(path.join(ASSET_BASE, "web", "ecp_SCPD.xml"));
     res.setHeader("content-type", "application/xml");
     res.send(file);
 }
@@ -645,7 +654,7 @@ export function getMacAddress() {
 }
 
 function getAppIconPath(appID) {
-    const fallbackIcon = path.join(__dirname, "images", "channel-icon.png");
+    const fallbackIcon = path.join(ASSET_BASE, "images", "channel-icon.png");
     const iconPath = device.appList.find((app) => app.id === appID)?.icon.replaceAll("file://", "");
     return iconPath && fs.existsSync(iconPath) ? iconPath : fallbackIcon;
 }

--- a/test/integration/ecp-rest.spec.js
+++ b/test/integration/ecp-rest.spec.js
@@ -161,16 +161,33 @@ describe("ECP REST API", () => {
     });
 
     describe("endpoints that read bundled files", () => {
-        // These resolve paths with path.join(__dirname, ...). Under vite-node __dirname is
-        // src/server/, not the webpack bundle's app/ directory, so the assets are absent.
-        // They work in the packaged app; only the test environment cannot reach them.
-        it.each(["/device-image.png", "/ecp_SCPD.xml", "/query/icon/dev"])(
-            "%s fails in the test environment because __dirname differs",
-            async (route) => {
-                const response = await fetch(`${base}${route}`);
-                expect(response.status).toBeGreaterThanOrEqual(400);
-            }
-        );
+        it("serves the device image", async () => {
+            const response = await fetch(`${base}/device-image.png`);
+            expect(response.status).toBe(200);
+            expect(response.headers.get("content-type")).toContain("image/png");
+            const body = Buffer.from(await response.arrayBuffer());
+            expect(body.length).toBeGreaterThan(0);
+            // PNG magic number, so a stub or an error page would not pass.
+            expect(body.subarray(0, 4)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+        });
+
+        it.each(["/ecp_SCPD.xml", "/dial_SCPD.xml"])("serves %s", async (route) => {
+            const response = await fetch(`${base}${route}`);
+            expect(response.status).toBe(200);
+            expect(response.headers.get("content-type")).toContain("application/xml");
+            const body = await response.text();
+            expect(body).toContain("<?xml");
+            expect(body).toContain("scpd");
+        });
+
+        it("serves the fallback icon for an app with no icon on disk", async () => {
+            // The fixture's icon path does not exist, so this exercises the fallback.
+            const response = await fetch(`${base}/query/icon/dev`);
+            expect(response.status).toBe(200);
+            expect(response.headers.get("content-type")).toContain("image/png");
+            const body = Buffer.from(await response.arrayBuffer());
+            expect(body.subarray(0, 4)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+        });
     });
 });
 


### PR DESCRIPTION
> **Stacked on #297** — base is `fix/ecp-device-data-guard`, not `master`, because both touch `src/server/ecp.js`. Merge that one first and this retargets automatically.

## Problem

Three ECP routes read files relative to `__dirname`:

| route | asset |
| --- | --- |
| `/device-image.png` | `images/device-image.png` |
| `/ecp_SCPD.xml`, `/dial_SCPD.xml` | `web/ecp_SCPD.xml` |
| `/query/icon/:appID` | `images/channel-icon.png` (fallback) |

Bundled, this module is `app/main.js`, so `__dirname` is `app/` — next to the copied `images/` and `web/`. Loaded straight from source it's `src/server/`, while the same assets live in `src/app/`.

So these routes could only ever work in the packaged app, and had **no test coverage at all**.

## The tests made it worse

#296 compensated by asserting the routes *fail*:

```js
it.each(["/device-image.png", "/ecp_SCPD.xml", "/query/icon/dev"])(
    "%s fails in the test environment because __dirname differs",
    async (route) => {
        expect((await fetch(`${base}${route}`)).status).toBeGreaterThanOrEqual(400);
    }
);
```

That's worse than no coverage: a real regression in any of the three would go unnoticed, and anyone repairing the path resolution would red-fail the suite **for improving the app**.

## Fix

Resolve the asset base once, preferring the bundled layout and falling back to the source layout, so a single code path serves both:

```js
const ASSET_BASE =
    [__dirname, path.join(__dirname, "..", "app")].find((base) =>
        fs.existsSync(path.join(base, "images"))
    ) ?? __dirname;
```

## Tests

Negative assertions replaced with real ones — status, content type, and **PNG magic numbers** or an XML body, so a stub or an error page can't pass. `dial_SCPD.xml` is now covered too; it shares a handler and was never exercised.

Verified in **both** arrangements. The suite covers the unbundled path (534 passing), and all four routes were checked against the running packaged app:

```
/device-image.png      status=200 type=image/png        bytes=19175
/ecp_SCPD.xml          status=200 type=application/xml  bytes=292
/dial_SCPD.xml         status=200 type=application/xml  bytes=292
/query/icon/dev        status=200 type=image/png        bytes=12107
```

Part of the series discharging the bugs pinned by #296.

🤖 Generated with [Claude Code](https://claude.com/claude-code)