### PR TITLE
feat: resolve system theme setting to current application theme in editor initialization

### DIFF
--- a/src/app/editor.js
+++ b/src/app/editor.js
@@ -135,7 +135,10 @@ function main() {
     updateButtons();
     // Initialize the Monaco editor
     const preferences = api.getPreferences();
-    const theme = preferences?.simulator?.theme || "purple";
+    let theme = preferences?.simulator?.theme || "purple";
+    if (theme === "system") {
+        theme = __currentTheme();
+    }
     const editorPrefs = preferences?.editor || {};
     terminal.setColorTheme(theme === "light" ? "light" : "dark");
     editorManager = new MonacoManager(brsCodeField, theme, editorPrefs);

--- a/src/app/index.ejs
+++ b/src/app/index.ejs
@@ -85,7 +85,7 @@
                     <h3><i class="fa fa-exclamation-triangle" style="color: #f39c12; margin-right: 8px;"></i>BrightScript and SceneGraph Support</h3>
                 </div>
                 <div class="modal-content">
-                    <p>This version of the Simulator can execute BrightScript language code compatible with Roku OS 15.3. It also includes SceneGraph support which is currently in <strong>beta stage</strong>.</p>
+                    <p>This version of the Simulator can execute <b>BrightScript</b> language code compatible with Roku OS 15.3. It also includes full <b>SceneGraph</b> support, which is currently in <strong>beta</strong>.</p>
                     <p><strong>Please be aware of the following limitations:</strong></p>
                     <ul>
                         <li>SceneGraph components may not render correctly</li>
@@ -93,7 +93,7 @@
                         <li>Check all <a href="https://github.com/lvcabral/brs-engine/blob/scenegraph/docs/limitations.md" target="_blank">current limitations</a> for more details</li>
                     </ul>
                     <p>🛠️ This simulator is intended for development purposes only. Always test your apps on actual Roku devices before release.</p>
-                    <p>🤝 If you found issues or have suggestions, remember that this is an open source project, feel free to contribute!</p>
+                    <p>🤝 If you found issues or have suggestions, remember that this is an open source project, feel free to <a href="https://github.com/lvcabral/brs-engine/issues" target="_blank">contribute</a>!</p>
                 </div>
                 <div class="modal-footer">
                     <div class="modal-checkbox">


### PR DESCRIPTION
When the theme was set to "System" the Monaco editor was always showing the "Light" theme, this PR fixes it.