### PR TITLE
fix: align localStorage key so 'don't show again' checkbox persists

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -674,7 +674,7 @@ function startupProcess() {
     // Function to handle dialog dismissal
     const handleDialogClose = () => {
         if (dontShowAgainCheckbox.checked) {
-            localStorage.setItem("sceneGraphWarningDismissed", "true");
+            localStorage.setItem("sceneGraphBetaDismissed", "true");
         }
         dialog.style.display = "none";
         if (runLastApp) {


### PR DESCRIPTION
The startup dialog read the dismissed flag from 'sceneGraphBetaDismissed' but the checkbox wrote to the old 'sceneGraphWarningDismissed' key, so the preference was never detected and the dialog always reappeared.