### PR TITLE
fix(services): drop remote connections on local-only toggle and document the setting

### DIFF
--- a/docs/remote-access.md
+++ b/docs/remote-access.md
@@ -2,6 +2,17 @@
 
 The **BrightScript Simulator** desktop app, the same way all Roku devices, implements some remote access services in order to enable automation and monitoring of the apps being executed. It allows among other possibilities, to integrate the simulator to the [VSCode BrightScript Extension](https://marketplace.visualstudio.com/items?itemName=celsoaf.brightscript) (see [how to integrate to VSCode](vscode-integration.md)). Below you will find a quick reference documentation about the services available.
 
+## Restricting Access to This Machine
+
+By default all the services below accept connections from any device on the local network, the same way a Roku device does. If you prefer to keep the simulator reachable only from the computer it is running on, uncheck **Allow connections from other devices on the network** at the top of the **Remote Access Services** section of the [Settings Screen](how-to-use.md#settings-screen).
+
+When that option is disabled:
+
+- The **Application Installer**, **ECP**, **Remote Console** and **Debug Server** only accept connections coming from `localhost` (`127.0.0.1` or `::1`). Requests from any other address are refused.
+- **SSDP** discovery advertisements are suppressed, so the simulator does not show up as a Roku device for the other machines scanning the network.
+
+The change is applied immediately to the services that are already running, and any connection already open from another machine is dropped. Because **SSDP** is turned off, the [VSCode BrightScript Extension](vscode-integration.md) will no longer discover the simulator automatically while this option is disabled — connecting to `127.0.0.1` still works.
+
 ## Application Installer
 
 This service allows you to remotely _side load_ an app in the simulator, it has a web interface that can be accessed using a browser, or any _HTTP_ client application. It also has a `Utilities` option where the user can request a screenshot of the currently running app.

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -353,6 +353,17 @@ export function getSettings(window) {
                             label: "Remote Access Services",
                             fields: [
                                 {
+                                    key: "remoteAccess",
+                                    type: "checkbox",
+                                    options: [
+                                        {
+                                            label: "Allow connections from other devices on the network",
+                                            value: "enabled",
+                                        },
+                                    ],
+                                    help: "When disabled, all services only accept connections from this machine",
+                                },
+                                {
                                     label: "Application Installer (Web)",
                                     key: "installer",
                                     type: "checkbox",
@@ -415,23 +426,6 @@ export function getSettings(window) {
                                         },
                                     ],
                                     help: "Debug Server can be accessed using an application such as PuTTY or terminal on Mac and Linux",
-                                },
-                                {
-                                    key: "placeholder2",
-                                    type: "message",
-                                    style: { width: "20%" },
-                                },
-                                {
-                                    label: "Allow Remote Access",
-                                    key: "remoteAccess",
-                                    type: "checkbox",
-                                    options: [
-                                        {
-                                            label: "Allow connections from other devices on the network",
-                                            value: "enabled",
-                                        },
-                                    ],
-                                    help: "When disabled, all services only accept connections from this machine. Changes take effect immediately.",
                                 },
                             ],
                         },

--- a/src/helpers/util.js
+++ b/src/helpers/util.js
@@ -23,6 +23,26 @@ export function isLocalhostAddress(addr) {
 }
 
 /**
+ * Function to disconnect every client that is not connected from this machine. Used when
+ * remote access is turned off while a service is running: the connection filters only run
+ * for new connections, so sessions established before the change would otherwise survive it.
+ * @param {Map<number, import("node:net").Socket>} clients - Map of connected client sockets
+ * @returns {number} - How many clients were disconnected
+ */
+export function destroyRemoteClients(clients) {
+    let dropped = 0;
+    for (const [id, client] of clients) {
+        if (isLocalhostAddress(client.remoteAddress)) {
+            continue;
+        }
+        client.destroy();
+        clients.delete(id);
+        dropped++;
+    }
+    return dropped;
+}
+
+/**
  * Function to check if a string is a valid IP address
  * @param {string} ip - The IP address to check
  * @returns {boolean} - True if the IP address is valid, false otherwise

--- a/src/server/debug.js
+++ b/src/server/debug.js
@@ -9,7 +9,7 @@ import { BrowserWindow } from "electron";
 import { DEBUG_PORT } from "../constants";
 import { HELP_COMMANDS, PRESS_HELP, getHelpText } from "./debugHelp";
 import { getPressKey } from "./debugKeys";
-import { isLocalhostAddress, getRokuOS } from "../helpers/util";
+import { isLocalhostAddress, destroyRemoteClients, getRokuOS } from "../helpers/util";
 import { reloadDevice } from "../helpers/window";
 import * as telnet from "net";
 
@@ -29,6 +29,9 @@ export let isDebugEnabled = false;
 
 export function setDebugLocalOnly(value) {
     localOnly = value;
+    if (localOnly) {
+        destroyRemoteClients(clients);
+    }
 }
 export function enableDebugServer(win, prefs, port = DEBUG_PORT, { localOnly: lo = false } = {}) {
     if (isDebugEnabled) {

--- a/src/server/ecp.js
+++ b/src/server/ecp.js
@@ -34,6 +34,7 @@ let ssdp;
 let currentApp;
 let localOnly = false;
 let ecpPort = ECP_PORT;
+let wss;
 
 const APP_ID_UNSAFE = /[^a-zA-Z0-9_\-.]/g;
 const sanitizeAppId = (id) => (id ?? "").replaceAll(APP_ID_UNSAFE, "");
@@ -71,11 +72,25 @@ function stopSSDPServer() {
     }
 }
 
+/**
+ * Closes the ECP-2 sessions opened from other machines. The upgrade handler only filters new
+ * connections, so a session established while remote access was allowed would otherwise keep
+ * receiving events after the user turned it off.
+ */
+function destroyRemoteSessions() {
+    for (const ws of wss?.clients ?? []) {
+        if (!isLocalhostAddress(ws.remoteAddress)) {
+            ws.terminate();
+        }
+    }
+}
+
 export function setECPLocalOnly(value) {
     localOnly = value;
     if (!isECPEnabled) return;
     if (localOnly) {
         stopSSDPServer();
+        destroyRemoteSessions();
     } else if (!ssdp) {
         startSSDPServer(ecpPort);
     }
@@ -142,8 +157,11 @@ export function enableECP(win, port = ECP_PORT, { localOnly: lo = false } = {}) 
                 startSSDPServer(port);
             }
             // Create ECP-2 WebSocket Server
-            const wss = new WebSocket.Server({ noServer: true });
-            wss.on("connection", function connection(ws) {
+            wss = new WebSocket.Server({ noServer: true });
+            wss.on("connection", function connection(ws, request) {
+                // Kept on the socket so a later switch to local-only can tell which sessions
+                // came from the network without reaching into the ws library internals.
+                ws.remoteAddress = request.socket.remoteAddress;
                 const auth = `{"notify":"authenticate","param-challenge":"jONQirQ3WxSQWdI9Zn0enA==","timestamp":"${process
                     .uptime()
                     .toFixed(3)}"}`;

--- a/src/server/telnet.js
+++ b/src/server/telnet.js
@@ -7,7 +7,7 @@
  *--------------------------------------------------------------------------------------------*/
 import { app, BrowserWindow, ipcMain } from "electron";
 import { consoleBuffer } from "../helpers/console";
-import { isLocalhostAddress } from "../helpers/util";
+import { isLocalhostAddress, destroyRemoteClients } from "../helpers/util";
 import { TELNET_PORT } from "../constants";
 import * as telnet from "net";
 let server;
@@ -19,6 +19,9 @@ let localOnly = false;
 export let isTelnetEnabled = false;
 export function setTelnetLocalOnly(value) {
     localOnly = value;
+    if (localOnly) {
+        destroyRemoteClients(clients);
+    }
 }
 export function enableTelnet(win, port = TELNET_PORT, { localOnly: lo = false } = {}) {
     if (isTelnetEnabled) {

--- a/test/integration/telnet-server.spec.js
+++ b/test/integration/telnet-server.spec.js
@@ -11,7 +11,13 @@ import { makeSharedObject, makeEngineDeviceInfo } from "../fixtures/sharedObject
 import { getFreePort } from "../helpers/freePort.js";
 import { waitForSend } from "../helpers/fakeWindow.js";
 import { connectSocket } from "../helpers/socketClient.js";
-import { enableTelnet, disableTelnet, subscribeTelnet, unsubscribeTelnet } from "../../src/server/telnet";
+import {
+    enableTelnet,
+    disableTelnet,
+    setTelnetLocalOnly,
+    subscribeTelnet,
+    unsubscribeTelnet,
+} from "../../src/server/telnet";
 
 /**
  * The remote console on a real TCP socket.
@@ -167,6 +173,28 @@ describe("telnet server", () => {
             client.write("quit\r\n");
             const [sent] = await waitForSend(win, "closeChannel");
             expect(sent.args[0]).toBe("EXIT_BRIGHTSCRIPT_STOP");
+        });
+    });
+
+    describe("local-only mode", () => {
+        afterEach(() => {
+            setTelnetLocalOnly(false);
+        });
+
+        // Which clients get dropped is covered by destroyRemoteClients in the util spec; a
+        // real socket here can only ever be loopback, so what this guards is the other half:
+        // turning remote access off must not disconnect the session on this machine.
+        it("keeps a loopback session alive when remote access is turned off", async () => {
+            const client = await connect();
+            client.clear();
+
+            setTelnetLocalOnly(true);
+            await new Promise((resolve) => setTimeout(resolve, 100));
+            expect(client.closed).toBe(false);
+
+            client.write("bt\r\n");
+            const [sent] = await waitForSend(win, "debugCommand");
+            expect(sent.args[0]).toBe("bt");
         });
     });
 });

--- a/test/unit/helpers/util.spec.js
+++ b/test/unit/helpers/util.spec.js
@@ -13,6 +13,7 @@ import {
     isValidIP,
     isValidUrl,
     isLocalhostAddress,
+    destroyRemoteClients,
     formatPath,
     getRokuOS,
     readJsonFile,
@@ -100,6 +101,50 @@ describe("isLocalhostAddress", () => {
     it("rejects undefined and null without throwing", () => {
         expect(isLocalhostAddress(undefined)).toBe(false);
         expect(isLocalhostAddress(null)).toBe(false);
+    });
+});
+
+describe("destroyRemoteClients", () => {
+    const fakeClient = (remoteAddress) => ({ remoteAddress, destroy: vi.fn() });
+
+    it("drops the clients connected from the network and keeps the local ones", () => {
+        const local = fakeClient("127.0.0.1");
+        const localV6 = fakeClient("::1");
+        const mapped = fakeClient("::ffff:127.0.0.1");
+        const remote = fakeClient("192.0.2.10");
+        const remoteV6 = fakeClient("::ffff:192.0.2.10");
+        const clients = new Map([
+            [0, local],
+            [1, remote],
+            [2, localV6],
+            [3, remoteV6],
+            [4, mapped],
+        ]);
+
+        expect(destroyRemoteClients(clients)).toBe(2);
+        expect(remote.destroy).toHaveBeenCalled();
+        expect(remoteV6.destroy).toHaveBeenCalled();
+        expect(local.destroy).not.toHaveBeenCalled();
+        expect(localV6.destroy).not.toHaveBeenCalled();
+        expect(mapped.destroy).not.toHaveBeenCalled();
+        // The dropped ids are removed so a later broadcast does not write to a dead socket.
+        expect([...clients.keys()]).toEqual([0, 2, 4]);
+    });
+
+    it("drops a client whose socket was already torn down", () => {
+        // A destroyed socket reports no remote address, so it cannot be proven local.
+        const stale = fakeClient(undefined);
+        const clients = new Map([[0, stale]]);
+
+        expect(destroyRemoteClients(clients)).toBe(1);
+        expect(stale.destroy).toHaveBeenCalled();
+        expect(clients.size).toBe(0);
+    });
+
+    it("does nothing when there are no clients", () => {
+        const clients = new Map();
+        expect(destroyRemoteClients(clients)).toBe(0);
+        expect(clients.size).toBe(0);
     });
 });
 


### PR DESCRIPTION
Follow-up to #314, closing the two items left open in that review.

## 1. Connections opened before the toggle survived it

The loopback filters from #314 run at connection time only:

- `telnet.js` / `debug.js` check inside `server.on("connection")`
- `ecp.js` checks inside `server.on("upgrade")`

So a telnet, debug or ECP-2 session established while remote access was allowed kept working after the user unchecked the setting. The web installer was already fine — it checks `req.socket.remoteAddress` on every request, so keep-alive sockets are re-checked and nothing needed to change there.

Now:

- `setTelnetLocalOnly` and `setDebugLocalOnly` disconnect the clients that are not on this machine, via a shared `destroyRemoteClients()` helper in `helpers/util.js` (both modules keep the same `Map<id, socket>` shape).
- `setECPLocalOnly` terminates the ECP-2 sessions opened from the network. `wss` moved to module scope, and the socket now carries the address it was upgraded from — `ws.remoteAddress = request.socket.remoteAddress` — so the check doesn't depend on the `ws` library internals.

## 2. Documentation

`docs/remote-access.md` gets a **Restricting Access to This Machine** section covering what the option turns off, that SSDP discovery stops with it, and that the VSCode extension will no longer auto-discover the simulator while it is off (connecting to `127.0.0.1` still works).

`docs/how-to-use.md` was left alone — its Settings Screen section is a screenshot and one sentence, it does not enumerate individual settings.

## Also included

The first commit is the settings reordering from your working copy: **Allow Remote Access** moves to the top of the Remote Access Services group (and the `placeholder2` spacer goes away), since it applies to every service listed under it.

## Tests

`npm test` → **577 pass / 34 files** · `npm run lint` clean · `npm run prettier` clean.

- `destroyRemoteClients` unit tests in `test/unit/helpers/util.spec.js` cover IPv4/IPv6/IPv4-mapped loopback vs. remote, map cleanup so a later broadcast can't write to a dead socket, a socket already torn down (no `remoteAddress`), and the empty case.
- A telnet integration test asserts the other half — flipping to local-only must **not** drop the loopback session, which a real socket in CI is the only kind of client that can be.

The UI hasn't been exercised in a running app; this is tests, lint and static review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
