### PR TITLE
fix: restore minimum window size overridden by custom-electron-titlebar

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -189,7 +189,8 @@ app.on("ready", () => {
         )
         .then(() => {
             firstLoad = false;
-            attachTitlebarToWindow(mainWindow);
+            const [mw, mh] = mainWindow.getMinimumSize();
+            attachTitlebarToWindow(mainWindow, { minWidth: mw, minHeight: mh });
             processArgv(mainWindow, startup);
             mainWindow.show();
             mainWindow.focus({ steal: true });


### PR DESCRIPTION
The attachTitlebarToWindow() function from custom-electron-titlebar defaults to Math.max(currentWindowWidth, 400) for minWidth and Math.max(currentWindowHeight, 270) for minHeight when no explicit values are passed. Since the window starts at 1280x770, this was effectively locking the minimum size to 1280x770, overriding the intended 346x264 minimum set by setMinimumSize().

Pass the already-configured minimum size to attachTitlebarToWindow() so the library respects it instead of replacing it with the current window dimensions.