### PR TITLE
feat: Live rendezvous logging via brs-engine API & ECP endpoints

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -375,6 +375,9 @@ api.receive("setAudioMute", function (mute) {
 api.receive("setPerfStats", function (enabled) {
     brs.enableStats(enabled);
 });
+api.receive("setRendezvousLog", function (enabled) {
+    brs.setRendezvousLog(enabled);
+});
 api.receive("mountExternalVolume", function (zipData, label = "External volume") {
     try {
         const zipBuffer = getExternalVolumeArrayBuffer(zipData);

--- a/src/app/preloadKeys.js
+++ b/src/app/preloadKeys.js
@@ -73,6 +73,7 @@ const RECEIVE_CHANNELS = [
     "mountExternalVolume",
     "unmountExternalVolume",
     "showToast",
+    "setRendezvousLog",
 ];
 
 /**

--- a/src/server/debug.js
+++ b/src/server/debug.js
@@ -11,6 +11,7 @@ import { HELP_COMMANDS, PRESS_HELP, getHelpText } from "./debugHelp";
 import { getPressKey } from "./debugKeys";
 import { isLocalhostAddress, destroyRemoteClients, getRokuOS } from "../helpers/util";
 import { reloadDevice } from "../helpers/window";
+import { setRendezvousTracking } from "./ecp";
 import * as telnet from "net";
 
 let server;
@@ -251,6 +252,7 @@ function handleLogRendezvous(arg, client) {
         if (window) {
             window.webContents.send("setRendezvousLog", rendezvousTrackingEnabled);
         }
+        setRendezvousTracking(rendezvousTrackingEnabled);
     } else {
         state ||= rendezvousTrackingEnabled ? "on" : "off";
     }

--- a/src/server/debug.js
+++ b/src/server/debug.js
@@ -248,6 +248,9 @@ function handleLogRendezvous(arg, client) {
     let state = arg;
     if (state && ["on", "off"].includes(state)) {
         rendezvousTrackingEnabled = state === "on";
+        if (window) {
+            window.webContents.send("setRendezvousLog", rendezvousTrackingEnabled);
+        }
     } else {
         state ||= rendezvousTrackingEnabled ? "on" : "off";
     }

--- a/src/server/ecp.js
+++ b/src/server/ecp.js
@@ -34,6 +34,7 @@ let ssdp;
 let currentApp;
 let localOnly = false;
 let ecpPort = ECP_PORT;
+let rendezvousTrackingEnabled = false;
 let wss;
 
 const APP_ID_UNSAFE = /[^a-zA-Z0-9_\-.]/g;
@@ -129,6 +130,10 @@ export function enableECP(win, port = ECP_PORT, { localOnly: lo = false } = {}) 
     ecp.get("/query/registry/:appID", sendRegistry);
     ecp.get("/query/graphics-frame-rate", sendGraphicsFrameRate);
     ecp.get("/query/app-state/:appID", sendAppState);
+    ecp.get("/query/sgrendezvous", sendRendezvousQuery);
+    ecp.post("/sgrendezvous/track", sendRendezvousTrack);
+    ecp.post("/sgrendezvous/track/:channelId", sendRendezvousTrack);
+    ecp.post("/sgrendezvous/untrack", sendRendezvousUntrack);
     ecp.post("/input", sendInput);
     ecp.post("/input/:appID", sendInput);
     ecp.post("/launch/:appID", sendLaunchApp);
@@ -383,6 +388,25 @@ function sendKeyUp(req, res) {
 function sendKeyPress(req, res) {
     window.webContents.send("postKeyPress", req.params.key);
     res.end();
+}
+
+function sendRendezvousTrack(req, res) {
+    rendezvousTrackingEnabled = true;
+    window?.webContents.send("setRendezvousLog", true);
+    res.setHeader("content-type", "application/xml");
+    res.send(genRendezvousXml(true, false));
+}
+
+function sendRendezvousUntrack(req, res) {
+    rendezvousTrackingEnabled = false;
+    window?.webContents.send("setRendezvousLog", false);
+    res.setHeader("content-type", "application/xml");
+    res.send(genRendezvousXml(false, false));
+}
+
+function sendRendezvousQuery(req, res) {
+    res.setHeader("content-type", "application/xml");
+    res.send(genRendezvousXml(rendezvousTrackingEnabled, true));
 }
 
 // Content Generation Functions
@@ -669,6 +693,32 @@ export function genAppState(appID, encrypt) {
         console.error("Error generating app state XML:", error);
         return "";
     }
+}
+
+export function genRendezvousXml(trackingEnabled, isQuery) {
+    const xml = xmlbuilder.create("sgrendezvous");
+    if (isQuery) {
+        const data = xml.ele("data");
+        data.ele("tracking-enabled", {}, trackingEnabled);
+        data.ele("plugin-id", {}, currentApp?.id ?? "dev");
+        data.ele("drop-count", {}, 0);
+        data.ele("count", {}, 0);
+        xml.ele("timestamp", {}, `${Date.now()}`);
+    } else {
+        xml.ele("tracking-enabled", {}, trackingEnabled);
+    }
+    xml.ele("status", {}, "OK");
+    return xml.end({ pretty: true });
+}
+
+/**
+ * Updates the ECP-side rendezvous tracking flag. Called by the debug server
+ * when the user toggles `logrendezvous on/off` from the telnet console, so
+ * that a subsequent `GET /query/sgrendezvous` reflects the current state.
+ * @param {boolean} enabled - Whether rendezvous tracking is on
+ */
+export function setRendezvousTracking(enabled) {
+    rendezvousTrackingEnabled = enabled;
 }
 
 // Helper Functions

--- a/test/integration/debug-server.spec.js
+++ b/test/integration/debug-server.spec.js
@@ -137,6 +137,21 @@ describe("debug server", () => {
         expect(await run(client, "logrendezvous")).toMatch(/off/i);
     });
 
+    it("forwards rendezvous logging toggle to the renderer via IPC", async () => {
+        const client = await connect();
+        win.sent.length = 0;
+        await run(client, "logrendezvous on");
+        const onMsg = win.sent.find((m) => m.channel === "setRendezvousLog");
+        expect(onMsg).toBeDefined();
+        expect(onMsg.args[0]).toBe(true);
+
+        win.sent.length = 0;
+        await run(client, "logrendezvous off");
+        const offMsg = win.sent.find((m) => m.channel === "setRendezvousLog");
+        expect(offMsg).toBeDefined();
+        expect(offMsg.args[0]).toBe(false);
+    });
+
     it("sends one key per character of a press argument, in order", async () => {
         const client = await connect();
         client.write("press hus\r\n");

--- a/test/integration/ecp-rest.spec.js
+++ b/test/integration/ecp-rest.spec.js
@@ -180,6 +180,59 @@ describe("ECP REST API", () => {
             expect(body.subarray(0, 4)).toEqual(Buffer.from([0x89, 0x50, 0x4e, 0x47]));
         });
     });
+
+    describe("sgrendezvous tracking", () => {
+        it("enables tracking via POST /sgrendezvous/track", async () => {
+            win.sent.length = 0;
+            const response = await fetch(`${base}/sgrendezvous/track`, { method: "POST" });
+            expect(response.status).toBe(200);
+            const body = await response.text();
+            expect(body).toContain("<tracking-enabled>true</tracking-enabled>");
+            expect(body).toContain("<status>OK</status>");
+            const ipcMsg = win.sentOn("setRendezvousLog");
+            expect(ipcMsg).toHaveLength(1);
+            expect(ipcMsg[0].args[0]).toBe(true);
+        });
+
+        it("accepts an optional channelId on track", async () => {
+            const response = await fetch(`${base}/sgrendezvous/track/dev`, { method: "POST" });
+            expect(response.status).toBe(200);
+            const body = await response.text();
+            expect(body).toContain("<tracking-enabled>true</tracking-enabled>");
+        });
+
+        it("returns tracking status via GET /query/sgrendezvous", async () => {
+            // First enable tracking
+            await fetch(`${base}/sgrendezvous/track`, { method: "POST" });
+            const response = await fetch(`${base}/query/sgrendezvous`);
+            expect(response.status).toBe(200);
+            const body = await response.text();
+            expect(body).toContain("<tracking-enabled>true</tracking-enabled>");
+            expect(body).toContain("<count>0</count>");
+            expect(body).toContain("<drop-count>0</drop-count>");
+            expect(body).toContain("<timestamp>");
+            expect(body).toContain("<status>OK</status>");
+        });
+
+        it("disables tracking via POST /sgrendezvous/untrack", async () => {
+            win.sent.length = 0;
+            const response = await fetch(`${base}/sgrendezvous/untrack`, { method: "POST" });
+            expect(response.status).toBe(200);
+            const body = await response.text();
+            expect(body).toContain("<tracking-enabled>false</tracking-enabled>");
+            expect(body).toContain("<status>OK</status>");
+            const ipcMsg = win.sentOn("setRendezvousLog");
+            expect(ipcMsg).toHaveLength(1);
+            expect(ipcMsg[0].args[0]).toBe(false);
+        });
+
+        it("query reflects disabled state after untrack", async () => {
+            await fetch(`${base}/sgrendezvous/untrack`, { method: "POST" });
+            const response = await fetch(`${base}/query/sgrendezvous`);
+            const body = await response.text();
+            expect(body).toContain("<tracking-enabled>false</tracking-enabled>");
+        });
+    });
 });
 
 describe("ECP REST API before the renderer reports device data", () => {

--- a/test/unit/app/__snapshots__/preloadKeys.spec.js.snap
+++ b/test/unit/app/__snapshots__/preloadKeys.spec.js.snap
@@ -59,5 +59,6 @@ exports[`IPC channel whitelists > matches their snapshots 2`] = `
   "mountExternalVolume",
   "unmountExternalVolume",
   "showToast",
+  "setRendezvousLog",
 ]
 `;

--- a/test/unit/app/preloadKeys.spec.js
+++ b/test/unit/app/preloadKeys.spec.js
@@ -39,7 +39,7 @@ describe("IPC channel whitelists", () => {
 
     it("holds the expected number of channels", () => {
         expect(SEND_CHANNELS).toHaveLength(24);
-        expect(RECEIVE_CHANNELS).toHaveLength(28);
+        expect(RECEIVE_CHANNELS).toHaveLength(29);
     });
 
     it("has no duplicates in either direction", () => {


### PR DESCRIPTION
Integrates the new `brs-engine` rendezvous logging API (`setRendezvousLog` / `getRendezvousLog`) into the simulator, making SceneGraph cross-thread rendezvous tracing controllable live — both from the telnet debug console and from the ECP REST API.

Previously, the `logrendezvous` debug command only toggled a local boolean without affecting the running engine. Now it drives `brs.setRendezvousLog()` in real time via IPC.

## What changed

### 1. Debug server → engine wiring (`cd008bc`)

The `logrendezvous on/off` telnet command now forwards the state to the Renderer via a new `setRendezvousLog` IPC channel, which calls `brs.setRendezvousLog()` on the engine. Follows the same pattern as the existing `fps_display` → `setPerfStats` feature.

**Files:**
- `src/server/debug.js` — sends `setRendezvousLog` IPC on toggle + syncs ECP state
- `src/app/app.js` — new `api.receive("setRendezvousLog", ...)` handler
- `src/app/preloadKeys.js` — whitelists the new IPC channel

### 2. ECP sgrendezvous endpoints (`ce35570`)

Implements the three Roku ECP endpoints for rendezvous tracking per the [External Control Protocol documentation](https://developer.roku.com/dev/docs/developer-tools/external-control-api.md):

| Method | Route | Description |
|--------|-------|-------------|
| `POST` | `/sgrendezvous/track[/:channelId]` | Enables rendezvous tracing |
| `GET` | `/query/sgrendezvous` | Returns current tracking status as XML |
| `POST` | `/sgrendezvous/untrack` | Disables rendezvous tracing |

XML responses match the Roku format:

```xml
<sgrendezvous>
    <tracking-enabled>true</tracking-enabled>
    <status>OK</status>
</sgrendezvous>
```

Query responses include the full structure with `<data>`, `plugin-id`, `count`, `drop-count`, and `timestamp`.

**State is shared bidirectionally** — toggling from telnet (`logrendezvous on`) updates the ECP query response, and toggling from ECP (`POST /sgrendezvous/track`) is reflected in the telnet state.

**Files:**
- `src/server/ecp.js` — 4 routes, 3 handlers, XML generator, `setRendezvousTracking` export
- `src/server/debug.js` — imports and calls `setRendezvousTracking` to keep ECP in sync

## Tests

- **6 new tests** added across integration suites:
  - `debug-server.spec.js` — verifies `setRendezvousLog` IPC is dispatched on `logrendezvous on/off`
  - `ecp-rest.spec.js` — 5 tests covering track, track with channelId, query, untrack, and state reflection
- Snapshot and channel count updated in `preloadKeys.spec.js`
- **All 583 tests pass** across 34 test files

## How to test manually

```bash
# Enable tracking via ECP
curl -d '' "http://localhost:8060/sgrendezvous/track"

# Query tracking status
curl "http://localhost:8060/query/sgrendezvous"

# Disable tracking via ECP
curl -d '' "http://localhost:8060/sgrendezvous/untrack"

# Or via telnet debug console (port 8085)
logrendezvous on
logrendezvous
logrendezvous off
```
