### PR TITLE
fix: reverted ECP rendezvous tracking IPC calls linked with the Debug service

### DIFF
--- a/src/server/debug.js
+++ b/src/server/debug.js
@@ -11,7 +11,6 @@ import { HELP_COMMANDS, PRESS_HELP, getHelpText } from "./debugHelp";
 import { getPressKey } from "./debugKeys";
 import { isLocalhostAddress, destroyRemoteClients, getRokuOS } from "../helpers/util";
 import { reloadDevice } from "../helpers/window";
-import { setRendezvousTracking } from "./ecp";
 import * as telnet from "net";
 
 let server;
@@ -252,7 +251,6 @@ function handleLogRendezvous(arg, client) {
         if (window) {
             window.webContents.send("setRendezvousLog", rendezvousTrackingEnabled);
         }
-        setRendezvousTracking(rendezvousTrackingEnabled);
     } else {
         state ||= rendezvousTrackingEnabled ? "on" : "off";
     }

--- a/src/server/ecp.js
+++ b/src/server/ecp.js
@@ -392,14 +392,16 @@ function sendKeyPress(req, res) {
 
 function sendRendezvousTrack(req, res) {
     rendezvousTrackingEnabled = true;
-    window?.webContents.send("setRendezvousLog", true);
+    // TODO: Will require a new IPC event to enable tracking for ECP
+    // window?.webContents.send("<< TBD >>", true);
     res.setHeader("content-type", "application/xml");
     res.send(genRendezvousXml(true, false));
 }
 
 function sendRendezvousUntrack(req, res) {
     rendezvousTrackingEnabled = false;
-    window?.webContents.send("setRendezvousLog", false);
+    // TODO: Will require a new IPC event to disable tracking for ECP
+    // window?.webContents.send("<< TBD >>", false);
     res.setHeader("content-type", "application/xml");
     res.send(genRendezvousXml(false, false));
 }
@@ -709,16 +711,6 @@ export function genRendezvousXml(trackingEnabled, isQuery) {
     }
     xml.ele("status", {}, "OK");
     return xml.end({ pretty: true });
-}
-
-/**
- * Updates the ECP-side rendezvous tracking flag. Called by the debug server
- * when the user toggles `logrendezvous on/off` from the telnet console, so
- * that a subsequent `GET /query/sgrendezvous` reflects the current state.
- * @param {boolean} enabled - Whether rendezvous tracking is on
- */
-export function setRendezvousTracking(enabled) {
-    rendezvousTrackingEnabled = enabled;
 }
 
 // Helper Functions

--- a/test/integration/ecp-rest.spec.js
+++ b/test/integration/ecp-rest.spec.js
@@ -189,9 +189,6 @@ describe("ECP REST API", () => {
             const body = await response.text();
             expect(body).toContain("<tracking-enabled>true</tracking-enabled>");
             expect(body).toContain("<status>OK</status>");
-            const ipcMsg = win.sentOn("setRendezvousLog");
-            expect(ipcMsg).toHaveLength(1);
-            expect(ipcMsg[0].args[0]).toBe(true);
         });
 
         it("accepts an optional channelId on track", async () => {
@@ -221,9 +218,6 @@ describe("ECP REST API", () => {
             const body = await response.text();
             expect(body).toContain("<tracking-enabled>false</tracking-enabled>");
             expect(body).toContain("<status>OK</status>");
-            const ipcMsg = win.sentOn("setRendezvousLog");
-            expect(ipcMsg).toHaveLength(1);
-            expect(ipcMsg[0].args[0]).toBe(false);
         });
 
         it("query reflects disabled state after untrack", async () => {


### PR DESCRIPTION
The ECP service does not share the same flag as the Debug service to enable/disable the rendezvous tracking, these are two independent logging and current brs-engine only supports the telnet logging. Left the endpoints configuration, as mocks for now.