### PR TITLE
fix: console buffer losing warning/error coloring when editor opens late

### DIFF
--- a/src/app/app.js
+++ b/src/app/app.js
@@ -131,7 +131,7 @@ async function main() {
                 api.send("debugStarted");
                 showToast(`App stopped and Micro Debugger is active!`);
             } else if (typeof data.content === "string") {
-                api.send("telnet", data.content);
+                api.send("telnet", data.content, data.level);
             }
             if (["stop", "pause", "continue"].includes(data.level)) {
                 debugMode = data.level;

--- a/src/app/editor.js
+++ b/src/app/editor.js
@@ -78,8 +78,12 @@ const terminal = new WebTerminal({
     autoFocus: false,
 });
 if (consoleBuffer?.length) {
-    for (const value of consoleBuffer) {
-        updateTerminal(value);
+    for (const entry of consoleBuffer) {
+        if (typeof entry === "object" && entry !== null) {
+            updateTerminal(entry.text, entry.level);
+        } else {
+            updateTerminal(entry);
+        }
     }
 }
 terminal.idle();

--- a/src/app/preload.js
+++ b/src/app/preload.js
@@ -137,9 +137,9 @@ contextBridge.exposeInMainWorld("api", {
     processPlatform: () => {
         return process.platform;
     },
-    send: (channel, data) => {
+    send: (channel, ...args) => {
         if (SEND_CHANNELS.includes(channel)) {
-            ipcRenderer.send(channel, data);
+            ipcRenderer.send(channel, ...args);
         } else {
             console.warn(`api.send() - invalid channel: ${channel}`);
         }

--- a/src/helpers/console.js
+++ b/src/helpers/console.js
@@ -10,12 +10,12 @@ import { ipcMain } from "electron";
 const BUFFER_SIZE = 700;
 export const consoleBuffer = [];
 
-ipcMain.on("telnet", (event, text) => {
+ipcMain.on("telnet", (event, text, level) => {
     if (text !== undefined) {
         if (consoleBuffer.length >= BUFFER_SIZE) {
             consoleBuffer.shift();
         }
-        consoleBuffer.push(text);
+        consoleBuffer.push({ text, level: level || "print" });
     }
 });
 

--- a/src/server/telnet.js
+++ b/src/server/telnet.js
@@ -51,8 +51,8 @@ export function enableTelnet(win, port = TELNET_PORT, { localOnly: lo = false } 
             lines.delete(id);
         });
         client.write(`Connected to ${app.getName()}\r\n`);
-        consoleBuffer.forEach((value) => {
-            client.write(value);
+        consoleBuffer.forEach((entry) => {
+            client.write(entry.text ?? entry);
         });
         clients.set(id, client);
         lines.set(id, "");


### PR DESCRIPTION
When the editor/console window was opened **after** warnings or errors had already been logged, the console displayed the buffered lines but rendered them all in the default color — warnings (yellow) and errors (red) appeared as plain text, indistinguishable from normal `print` output.

This happened because the console ring buffer in `console.js` only stored the raw text string, discarding the severity `level`. When the editor replayed the buffer on open, every line defaulted to `level = "print"`, bypassing the colorization logic in `updateTerminal()`.

## Root Cause

The data flow had three gaps:

1. **`app.js`** sent only `data.content` on the `telnet` IPC channel, dropping `data.level`
2. **`preload.js`** `send()` accepted only `(channel, data)`, silently discarding any additional arguments
3. **`console.js`** pushed plain strings into the buffer — no level metadata was preserved

## Solution

Preserve the log level alongside the text throughout the entire pipeline:

| File | Change |
|:--|:--|
| `src/app/app.js` | Send `data.level` as a second argument on the `telnet` IPC channel |
| `src/app/preload.js` | Change `send(channel, data)` → `send(channel, ...args)` so extra IPC arguments are forwarded |
| `src/helpers/console.js` | Store `{ text, level }` objects in the buffer instead of plain strings |
| `src/server/telnet.js` | Extract `.text` from buffer entries when replaying to telnet clients (with plain-string fallback) |
| `src/app/editor.js` | Extract both `.text` and `.level` when replaying the buffer, so `updateTerminal()` applies the correct coloring |

## Testing

- All **583 existing tests pass** (34 test files) — no regressions
- The telnet server integration tests (including buffer replay to late-joining clients) continue to work correctly with the new object format
