### PR TITLE
fix: startup race between queued app launch and auto-start logic

### DIFF
--- a/build/start.js
+++ b/build/start.js
@@ -14,8 +14,6 @@ const watching = compiler.watch({}, (err, stats) => {
         electron,
         ["."].concat(
           process.argv.slice(2) //"--devtools"
-          //'-w 8888'//'--mode=sd'//'--pwd=newpwd'//"--installer" //"-e"
-          //  ["-o C:\\Projects\\Roku\\Lode-Runner-Roku\\out\\roku-deploy.zip", //  "--fullscreen" ]
         ),
         { stdio: "inherit" }
       )

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -76,9 +76,9 @@ This screen can be used to write (or import) BrightScript code and run it direct
 Here are **optional** arguments you can use when starting the simulator at the command line:
 
 ```shell
-"BrightScript Simulator" [-o <path>] [-f] [-m <dm>] [-e] [-r] [-b] [-w [<port>]] [-p <newpwd>] [-c] [-d]
+"BrightScript Simulator" [-o <path>] [-f] [-m <dm>] [-e] [-r] [-b] [-s] [-w [<port>]] [-p <newpwd>] [-c] [-d]
 
-"BrightScript Simulator" [<path>] [--fullscreen] [--mode=<dm>] [--ecp] [--rc] [--debug]
+"BrightScript Simulator" [<path>] [--fullscreen] [--mode=<dm>] [--ecp] [--rc] [--debug] [--screen]
                         [--web[=<port>]] [--pwd=<newpwd>] [--console] [--devtools]
 ```
 
@@ -90,6 +90,7 @@ Here are **optional** arguments you can use when starting the simulator at the c
 |**-e** or **--ecp**                     | Enables [ECP and SSDP servers](https://developer.roku.com/en-ca/docs/developer-program/debugging/external-control-api.md) to allow remote control and detection.|
 |**-r** or **--rc**                      | Enables a telnet server on port 8085 to allow **Remote Console** monitoring. |
 |**-b** or **--debug**                   | Enables the **Debug Server** on port 8080 for remote debugging commands.     |
+|**-s** or **--screen**                  | Enables **Remote Screen**, a WebRTC video feed of the display, on port 8090. |
 |**-w** `[<port>]` or **--web**`[=<port>]`| Enables **Web Installer** on port 80 optionally set and save a custom `<port>`.|
 |**-p** `<newpwd>` or **--pwd=**`<newpwd>`| Changes the **Web Installer** password and saves it on local storage.       |
 |**-c** or **--console**                 | Opens the **BrightScript console** when starting the simulator.              |

--- a/docs/how-to-use.md
+++ b/docs/how-to-use.md
@@ -76,9 +76,9 @@ This screen can be used to write (or import) BrightScript code and run it direct
 Here are **optional** arguments you can use when starting the simulator at the command line:
 
 ```shell
-"BrightScript Simulator" [-o <path>] [-f] [-m <dm>] [-e] [-t] [-w [<port>]] [-p <newpwd>] [-c] [-d]
+"BrightScript Simulator" [-o <path>] [-f] [-m <dm>] [-e] [-r] [-b] [-w [<port>]] [-p <newpwd>] [-c] [-d]
 
-"BrightScript Simulator" [<path>] [--fullscreen] [--mode=<dm>] [--ecp] [--rc]
+"BrightScript Simulator" [<path>] [--fullscreen] [--mode=<dm>] [--ecp] [--rc] [--debug]
                         [--web[=<port>]] [--pwd=<newpwd>] [--console] [--devtools]
 ```
 
@@ -89,7 +89,9 @@ Here are **optional** arguments you can use when starting the simulator at the c
 |**-m** `<dm>` or **--mode=**`<dm>`      | Changes the **display mode**. Options are: `sd`, `hd`, or `fhd`.             |
 |**-e** or **--ecp**                     | Enables [ECP and SSDP servers](https://developer.roku.com/en-ca/docs/developer-program/debugging/external-control-api.md) to allow remote control and detection.|
 |**-r** or **--rc**                      | Enables a telnet server on port 8085 to allow **Remote Console** monitoring. |
+|**-b** or **--debug**                   | Enables the **Debug Server** on port 8080 for remote debugging commands.     |
 |**-w** `[<port>]` or **--web**`[=<port>]`| Enables **Web Installer** on port 80 optionally set and save a custom `<port>`.|
 |**-p** `<newpwd>` or **--pwd=**`<newpwd>`| Changes the **Web Installer** password and saves it on local storage.       |
 |**-c** or **--console**                 | Opens the **BrightScript console** when starting the simulator.              |
 |**-d** or **--devtools**                | Opens the **developer tools** when starting the simulator.                   |
+

--- a/src/app/app.js
+++ b/src/app/app.js
@@ -63,6 +63,9 @@ let debugMode = "continue";
 let editor = null;
 let externalVolumeMountedLabel = "";
 let externalVolumeReadySent = false;
+let isAppStarting = false;
+let isEngineReady = false;
+let pendingExecute = null;
 
 // Initialize BrightScript Engine when window loads
 globalThis.addEventListener("load", main, false);
@@ -145,6 +148,16 @@ async function main() {
             api.send("reset");
         } else if (event === "version") {
             // brs-engine requests the version from the worker as the last step on initialize
+            isEngineReady = true;
+            if (pendingExecute) {
+                brs.execute(
+                    pendingExecute.filePath,
+                    pendingExecute.data,
+                    pendingExecute.options,
+                    pendingExecute.input
+                );
+                pendingExecute = null;
+            }
             startupProcess();
             if (!externalVolumeReadySent) {
                 externalVolumeReadySent = true;
@@ -240,6 +253,7 @@ api.receive("executeFile", function (filePath, data, clear, mute, debug, input) 
     }
 
     try {
+        isAppStarting = true;
         const fileExt = filePath.split(".").pop()?.toLowerCase().split("?")[0];
         let password = "";
         let debugState = !filePath.includes(BRS_HOME_APP_PATH);
@@ -255,18 +269,19 @@ api.receive("executeFile", function (filePath, data, clear, mute, debug, input) 
         if (brsHomeMode) {
             launchAppId = BRS_HOME_APP_PATH;
         }
-        brs.execute(
-            filePath.split("?")[0],
-            data,
-            {
-                clearDisplayOnExit: clear,
-                muteSound: mute,
-                debugOnCrash: debug,
-                password: password,
-            },
-            input
-        );
+        const options = {
+            clearDisplayOnExit: clear,
+            muteSound: mute,
+            debugOnCrash: debug,
+            password: password,
+        };
+        if (!isEngineReady) {
+            pendingExecute = { filePath: filePath.split("?")[0], data, options, input };
+            return;
+        }
+        brs.execute(filePath.split("?")[0], data, options, input);
     } catch (error) {
+        isAppStarting = false;
         const errorMsg = `Error opening ${filePath}:${error.message}`;
         console.error(errorMsg);
         showToast(errorMsg, 5000, true);
@@ -632,6 +647,7 @@ function appLoaded(appData) {
 }
 
 function appTerminated() {
+    isAppStarting = false;
     currentApp = structuredClone(defaultAppInfo);
     stats.style.visibility = "hidden";
     api.updateTitle(defaultTitle);
@@ -671,7 +687,8 @@ function startupProcess() {
     const closeButton = document.getElementById("close-scenegraph-warning");
     const dontShowAgainCheckbox = document.getElementById("dont-show-warning-again");
 
-    if (dontShowWarning || !dialog || !closeButton || !dontShowAgainCheckbox) {
+    const runStartupChoice = () => {
+        if (isAppStarting || currentApp.running) return;
         if (runLastApp) {
             setTimeout(() => startLastApp(), 300);
         } else if (splashVideoEnabled) {
@@ -679,6 +696,10 @@ function startupProcess() {
         } else if (brsHomeMode) {
             setTimeout(() => startHomeApp(), 300);
         }
+    };
+
+    if (dontShowWarning || !dialog || !closeButton || !dontShowAgainCheckbox) {
+        runStartupChoice();
         return;
     }
     // Show the dialog after a short delay to ensure UI is ready
@@ -691,13 +712,7 @@ function startupProcess() {
             localStorage.setItem("sceneGraphBetaDismissed", "true");
         }
         dialog.style.display = "none";
-        if (runLastApp) {
-            setTimeout(() => startLastApp(), 300);
-        } else if (splashVideoEnabled) {
-            setTimeout(() => startSplashVideo(), 300);
-        } else if (brsHomeMode) {
-            setTimeout(() => startHomeApp(), 300);
-        }
+        runStartupChoice();
     };
     closeButton.addEventListener("click", handleDialogClose);
     document.addEventListener("keydown", (event) => {
@@ -717,6 +732,7 @@ function startupProcess() {
 }
 
 function startSplashVideo() {
+    if (isAppStarting) return;
     const player = document.getElementById("player");
     if (!player) {
         return;
@@ -765,12 +781,13 @@ function startSplashVideo() {
 }
 
 function startHomeApp() {
-    if (brsHomeMode && !currentApp.running) {
+    if (brsHomeMode && !currentApp.running && !isAppStarting) {
         api.send("runFile", BRS_HOME_APP_PATH);
     }
 }
 
 function startLastApp() {
+    if (isAppStarting) return;
     if (appList.length > 0) {
         const lastApp = appList[0];
         if (lastApp.path.startsWith("http") || lastApp.path.startsWith("file:")) {

--- a/src/cliArgs.js
+++ b/src/cliArgs.js
@@ -12,7 +12,7 @@ export const cliArgumentsConfig = {
     // `w` belongs here with the other value-taking options: left undeclared, minimist
     // infers the type, so a bare `-w` becomes boolean true and `-w 8080` a number.
     string: ["o", "p", "m", "w"],
-    boolean: ["b", "c", "d", "e", "f", "r"],
+    boolean: ["b", "c", "d", "e", "f", "r", "s"],
     alias: {
         b: "debug",
         c: "console",
@@ -23,5 +23,6 @@ export const cliArgumentsConfig = {
         p: "pwd",
         m: "mode",
         r: "rc",
+        s: "screen",
     },
 };

--- a/src/cliArgs.js
+++ b/src/cliArgs.js
@@ -12,8 +12,9 @@ export const cliArgumentsConfig = {
     // `w` belongs here with the other value-taking options: left undeclared, minimist
     // infers the type, so a bare `-w` becomes boolean true and `-w 8080` a number.
     string: ["o", "p", "m", "w"],
-    boolean: ["c", "d", "e", "f", "r"],
+    boolean: ["b", "c", "d", "e", "f", "r"],
     alias: {
+        b: "debug",
         c: "console",
         d: "devtools",
         e: "ecp",

--- a/src/main.js
+++ b/src/main.js
@@ -347,10 +347,10 @@ function processArgv(mainWindow, startup = {}, cliArgs = argv, options = {}) {
     if (cliArgs?.ecp || (applyStartup && startupOptions.ecpEnabled)) {
         enableECP(mainWindow, ECP_PORT, { localOnly });
     }
-    if (cliArgs?.telnet || (applyStartup && startupOptions.telnetEnabled)) {
+    if (cliArgs?.rc || (applyStartup && startupOptions.telnetEnabled)) {
         enableTelnet(mainWindow, TELNET_PORT, { localOnly });
     }
-    if (applyStartup && startupOptions.debugServerEnabled) {
+    if (cliArgs?.debug || (applyStartup && startupOptions.debugServerEnabled)) {
         enableDebugServer(mainWindow, settings, DEBUG_PORT, { localOnly });
     }
     if (applyStartup && startupOptions.remoteScreenEnabled) {

--- a/src/main.js
+++ b/src/main.js
@@ -353,7 +353,7 @@ function processArgv(mainWindow, startup = {}, cliArgs = argv, options = {}) {
     if (cliArgs?.debug || (applyStartup && startupOptions.debugServerEnabled)) {
         enableDebugServer(mainWindow, settings, DEBUG_PORT, { localOnly });
     }
-    if (applyStartup && startupOptions.remoteScreenEnabled) {
+    if (cliArgs?.screen || (applyStartup && startupOptions.remoteScreenEnabled)) {
         enableRemoteScreen(mainWindow, REMOTE_SCREEN_PORT, { localOnly });
     }
     if (cliArgs?.pwd && cliArgs.pwd.trim() !== "") {

--- a/test/unit/cliArgs.spec.js
+++ b/test/unit/cliArgs.spec.js
@@ -29,6 +29,7 @@ describe("CLI aliases", () => {
         ["p", "pwd"],
         ["m", "mode"],
         ["r", "rc"],
+        ["s", "screen"],
     ])("aliases -%s to --%s", (short, long) => {
         expect(cliArgumentsConfig.alias[short]).toBe(long);
     });
@@ -42,13 +43,16 @@ describe("CLI aliases", () => {
 });
 
 describe("boolean flags", () => {
-    it.each(["console", "debug", "devtools", "ecp", "fullscreen", "rc"])("parses --%s as a boolean", (flag) => {
-        expect(parse(`--${flag}`)[flag]).toBe(true);
-    });
+    it.each(["console", "debug", "devtools", "ecp", "fullscreen", "rc", "screen"])(
+        "parses --%s as a boolean",
+        (flag) => {
+            expect(parse(`--${flag}`)[flag]).toBe(true);
+        }
+    );
 
     it("defaults every boolean flag to false", () => {
         const parsed = parse();
-        for (const flag of ["console", "debug", "devtools", "ecp", "fullscreen", "rc"]) {
+        for (const flag of ["console", "debug", "devtools", "ecp", "fullscreen", "rc", "screen"]) {
             expect(parsed[flag]).toBe(false);
         }
     });

--- a/test/unit/cliArgs.spec.js
+++ b/test/unit/cliArgs.spec.js
@@ -20,6 +20,7 @@ function parse(...args) {
 
 describe("CLI aliases", () => {
     it.each([
+        ["b", "debug"],
         ["c", "console"],
         ["d", "devtools"],
         ["e", "ecp"],
@@ -41,13 +42,13 @@ describe("CLI aliases", () => {
 });
 
 describe("boolean flags", () => {
-    it.each(["console", "devtools", "ecp", "fullscreen", "rc"])("parses --%s as a boolean", (flag) => {
+    it.each(["console", "debug", "devtools", "ecp", "fullscreen", "rc"])("parses --%s as a boolean", (flag) => {
         expect(parse(`--${flag}`)[flag]).toBe(true);
     });
 
     it("defaults every boolean flag to false", () => {
         const parsed = parse();
-        for (const flag of ["console", "devtools", "ecp", "fullscreen", "rc"]) {
+        for (const flag of ["console", "debug", "devtools", "ecp", "fullscreen", "rc"]) {
             expect(parsed[flag]).toBe(false);
         }
     });


### PR DESCRIPTION
## Summary
- Fixes a startup race: `executeFile` could arrive over IPC before the brs-engine worker reports `version`, and the auto-start logic in `startupProcess()` (splash video / home app / last app) had no way to know a launch was already in flight or loading, so it could start a second app concurrently. Adds `isEngineReady`/`pendingExecute` to defer `brs.execute()` until the engine is ready, and `isAppStarting` to guard the auto-start paths from the moment a launch is requested until the app reports running (or errors out — reset in the `catch` block so a thrown error can't leave it stuck permanently).
- Fixes `--rc`/`-r` telnet startup flag, which was reading a stale `cliArgs.telnet` key instead of `cliArgs.rc`.
- Adds `-b`/`--debug` CLI flag to enable the Debug Server (port 8080) at startup, following the existing `-e/--ecp` and `-r/--rc` pattern.
- Adds `-s`/`--screen` CLI flag to enable **Remote Screen** (the WebRTC video feed added in #322, port 8090) at startup, same pattern.
- Dedupes a repeated guard-and-dispatch block in `startupProcess()` into a shared `runStartupChoice()` helper.

Rebased onto `master` after #322 (Remote Screen) merged.

## Test plan
- [x] `npm test` — 686 tests passing
- [x] `npm run lint` / `npm run prettier` — clean (pre-existing, unrelated lint errors in `src/server/ecp.js`, `test/unit/server/ecp-xml.spec.js`, `test/integration/remotescreen-lifecycle.spec.js` not touched by this change)
- [ ] Manual: verify `-b`/`--debug` enables the debug server, `-r`/`--rc` enables telnet, and `-s`/`--screen` enables Remote Screen, at simulator startup
- [ ] Manual: verify no duplicate app launch when opening a file/URL immediately at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)