### PR TITLE
ci: add lint job, fix pending ESLint errors

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,29 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v4
+
+      - name: Install Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Run ESLint
+        run: npm run lint
+
+      - name: Check Prettier formatting
+        run: npm run prettier
+
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 15
@@ -44,7 +67,7 @@ jobs:
         run: npm test
 
   release:
-    needs: test
+    needs: [lint, test]
     # Push events only. Pull requests run the test job for feedback; building installers
     # on three platforms for every push to a PR branch would cost minutes and publish
     # nothing, since the release step is gated on a tag anyway.

--- a/src/server/ecp.js
+++ b/src/server/ecp.js
@@ -35,8 +35,6 @@ let currentApp;
 let localOnly = false;
 let ecpPort = ECP_PORT;
 let rendezvousTrackingEnabled = false;
-/** Maximum rendezvous events queued between two query/sgrendezvous calls (matches Roku's spec). */
-const MAX_RENDEZVOUS_QUEUE = 1000;
 const rendezvousQueue = [];
 let rendezvousDropCount = 0;
 let pendingRendezvousResolve = null;

--- a/test/integration/remotescreen-lifecycle.spec.js
+++ b/test/integration/remotescreen-lifecycle.spec.js
@@ -5,7 +5,7 @@
  *
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { describe, it, expect, beforeAll, beforeEach, afterAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, beforeEach, afterAll } from "vitest";
 import os from "node:os";
 import WebSocket from "ws";
 import { createFakeWindow, __registerWindow } from "../mocks/electron.js";

--- a/test/unit/server/ecp-xml.spec.js
+++ b/test/unit/server/ecp-xml.spec.js
@@ -276,7 +276,7 @@ describe("ECP payload builders", () => {
         it("includes event items with the correct fields", () => {
             const events = [
                 { id: 1, startTm: 100.5, endTm: 105.3, line: 42, file: "pkg:/components/Task.brs" },
-                { id: 2, startTm: 200.0, endTm: 210.7, line: 99, file: "pkg:/source/main.brs" },
+                { id: 2, startTm: 200, endTm: 210.7, line: 99, file: "pkg:/source/main.brs" },
             ];
             const xml = genSgRendezvousQueryXml(events, 3, true);
             expect(xml).toContain("<count>2</count>");


### PR DESCRIPTION
## Summary
- Adds a `lint` job to `.github/workflows/build.yml` running `npm run lint` (ESLint) and `npm run prettier` on `ubuntu-latest`, in parallel with the existing OS-matrix `test` job. `release` now depends on both `lint` and `test`.
- Fixes the three ESLint errors this surfaces:
  - `src/server/ecp.js`: removed an unused `MAX_RENDEZVOUS_QUEUE` constant left over from the rendezvous-tracking work (#323) — nothing ever read it.
  - `test/integration/remotescreen-lifecycle.spec.js`: removed an unused `afterEach` import.
  - `test/unit/server/ecp-xml.spec.js`: `200.0` → `200` (`unicorn/no-zero-fractions`).

## Test plan
- [x] `npm run lint` — clean
- [x] `npm run prettier` — clean
- [x] `npm test` — 682 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)