### PR TITLE
feat: add settings option to clear console on BrightScript app startup

### DIFF
--- a/src/app/editor.js
+++ b/src/app/editor.js
@@ -367,7 +367,16 @@ function updateButtons() {
 }
 
 function handleEngineEvents(event, data) {
-    if (event === "loaded") {
+    if (event === "loading") {
+        if (data === BRS_HOME_APP_PATH) {
+            return;
+        }
+        const preferences = api.getPreferences();
+        const simOptions = preferences?.simulator?.options || [];
+        if (simOptions.includes("clearConsoleOnStartup")) {
+            clearTerminal();
+        }
+    } else if (event === "loaded") {
         if (data.path === BRS_HOME_APP_PATH) {
             return;
         }

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -236,6 +236,10 @@ export function getSettings(window) {
                                             value: "consoleOnDebug",
                                         },
                                         {
+                                            label: "Clear the Console when BrightScript App starts",
+                                            value: "clearConsoleOnStartup",
+                                        },
+                                        {
                                             label: "Pause App when the Simulator loses the Focus",
                                             value: "pauseOnBlur",
                                         },


### PR DESCRIPTION
This PR introduces a new setting in the General tab that allows users to automatically clear the console output when a BrightScript application is launched.

### Changes Included:
* **Settings Option**: Added a new "Clear the Console on BrightScript App Startup" checkbox in **Settings -> General -> Simulator Options**.
* **Engine Event Hook**: Modified `editor.js` to intercept the engine's `loading` event and automatically invoke `clearTerminal()` before the app executes if the setting is enabled.
* **Home App Exception**: The Home app explicitly skips this logic and will not clear the console even if the setting is enabled. This ensures that the terminal remains intact while simply returning to or navigating the home screen.
* **Default State**: The setting defaults to disabled (false), maintaining backwards compatibility with the current console behavior.

## Files Modified
* `src/helpers/settings.js`
* `src/app/editor.js`

## Verification
- Opened Settings -> General and verified the new checkbox appears and is unchecked by default.
- Toggled the setting ON and verified the console output clears correctly upon sideloading/running a new app.
- Verified that returning to the Home App does not clear the console when the setting is enabled.
