### PR TITLE
feat: add persistence for Roku device discovery and dynamic peer roku menu label

### DIFF
--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -49,7 +49,7 @@ import {
     isRemoteScreenEnabled,
     setRemoteScreenLocalOnly,
 } from "../server/remotescreen";
-import { createMenu, createShortMenu, checkMenuItem } from "../menu/menuService";
+import { createMenu, createShortMenu, checkMenuItem, updatePeerRokuMenuLabels } from "../menu/menuService";
 import {
     WEB_INSTALLER_PORT,
     DEFAULT_USRPWD,
@@ -58,7 +58,7 @@ import {
     DEBUG_PORT,
     REMOTE_SCREEN_PORT,
 } from "../constants";
-import { getLocalIps, formatPath } from "./util";
+import { getLocalIps, formatPath, readJsonFile, writeJsonFile } from "./util";
 
 const isMacOS = process.platform === "darwin";
 const isWindows = process.platform === "win32";
@@ -66,6 +66,7 @@ const isLinux = process.platform === "linux";
 const timeZoneLabels = new Map();
 const discoveredDevices = new Map();
 const pendingMetadataRequests = new Set();
+const deviceCacheFile = path.resolve(app.getPath("userData"), "roku-devices.json");
 const w = 800;
 const h = 700;
 let settings;
@@ -1171,6 +1172,7 @@ export function getSettings(window) {
         if (preferences.customization) {
             setDeviceInfo("customization", "customFeatures", true);
         }
+        updatePeerRokuMenuLabels();
     });
     nativeTheme.on("updated", () => {
         if (settings.value("simulator.theme") === "system") {
@@ -2165,6 +2167,7 @@ async function discoverRokuDevices() {
                     console.warn("No Roku devices found on the local network.");
                 }
                 resolve(discoveredDevices.size);
+                saveDeviceCache();
             };
             if (metadataFetches.length > 0) {
                 Promise.allSettled(metadataFetches).then(finalize).catch(finalize);
@@ -2181,6 +2184,30 @@ export async function initRokuDeviceDiscovery() {
     } catch (error) {
         console.error(`Failed to discover Roku devices: ${error.message}`);
         return 0;
+    }
+}
+
+export function loadDeviceCache() {
+    try {
+        const cached = readJsonFile(deviceCacheFile);
+        if (Array.isArray(cached)) {
+            for (const entry of cached) {
+                if (entry.ip) {
+                    discoveredDevices.set(entry.ip, entry);
+                }
+            }
+        }
+    } catch (error) {
+        // Cache missing or corrupt — not a problem, discovery will populate it.
+    }
+}
+
+function saveDeviceCache() {
+    try {
+        const entries = Array.from(discoveredDevices.values());
+        writeJsonFile(deviceCacheFile, entries);
+    } catch (error) {
+        console.warn(`Unable to save Roku device cache: ${error.message}`);
     }
 }
 

--- a/src/main.js
+++ b/src/main.js
@@ -34,6 +34,7 @@ import {
     isMenuItemEnabled,
     getAppList,
     updateAppList,
+    updatePeerRokuMenuLabels,
 } from "./menu/menuService";
 import { loadFile } from "./helpers/files";
 import {
@@ -50,6 +51,7 @@ import {
     updateServerStatus,
     closeSettings,
     initRokuDeviceDiscovery,
+    loadDeviceCache,
 } from "./helpers/settings";
 import { createWindow, openCodeEditor, openDevTools, setAspectRatio, saveWindowState } from "./helpers/window";
 import { subscribeServerEvents } from "./helpers/events";
@@ -143,6 +145,7 @@ app.on("ready", () => {
     }
     // setup the titlebar main process
     setupTitlebar();
+    loadDeviceCache();
     createMenu();
     // Shared Object with Front End
     globalThis.sharedObject = {
@@ -186,7 +189,12 @@ app.on("ready", () => {
     initECP();
     // Initialize Roku device discovery
     setTimeout(() => {
-        initRokuDeviceDiscovery();
+        initRokuDeviceDiscovery().then(() => {
+            updatePeerRokuMenuLabels();
+            if (process.platform === "darwin") {
+                createMenu();
+            }
+        });
     }, 2000); // Delay to allow network services to start
     // Load Renderer
     mainWindow
@@ -329,6 +337,10 @@ function loadSettings(mainWindow, startup) {
         const peerRoku = getPeerRoku();
         checkMenuItem("peer-roku-deploy", peerRoku.deploy);
         checkMenuItem("peer-roku-control", peerRoku.syncControl);
+        updatePeerRokuMenuLabels();
+        if (process.platform === "darwin") {
+            createMenu();
+        }
     }
     if (settings.preferences.editor) {
         setDeviceInfo("editor", "logLevel");

--- a/src/menu/menuService.js
+++ b/src/menu/menuService.js
@@ -115,6 +115,27 @@ export function checkMenuItem(id, checked) {
     }
 }
 
+export function updatePeerRokuMenuLabels() {
+    let peerRoku;
+    try {
+        peerRoku = getPeerRoku();
+    } catch {
+        return; // Settings not initialised yet — nothing to label.
+    }
+    const suffix = peerRoku.friendlyName || peerRoku.ip;
+    const deployLabel = suffix ? `Deploy to Peer Roku (${suffix})` : "Deploy to Peer Roku";
+    // Update the template so the next buildFromTemplate picks it up
+    const deviceSub = deviceMenuTemplate.submenu;
+    const deployTpl = deviceSub.find((item) => item.id === "peer-roku-deploy");
+    if (deployTpl) deployTpl.label = deployLabel;
+    // Also update the live menu item (non-template rebuilds)
+    const appMenu = app.applicationMenu;
+    if (appMenu) {
+        const deployItem = appMenu.getMenuItemById("peer-roku-deploy");
+        if (deployItem) deployItem.label = deployLabel;
+    }
+}
+
 export function enableMenuItem(id, enabled) {
     const item = app.applicationMenu.getMenuItemById(id);
     if (item) {
@@ -221,6 +242,7 @@ function rebuildMenu(template = false) {
         }
         findItem("zip-empty").visible = recentFiles.zip.length === 0;
         findItem("file-clear").enabled = recentFiles.zip.length > 0;
+        updatePeerRokuMenuLabels();
         Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
         if (isMacOS && window) {
             if (appMenu.getMenuItemById("view-menu")) {
@@ -245,6 +267,7 @@ function rebuildMenu(template = false) {
                 const peerRoku = getPeerRoku();
                 checkMenuItem("peer-roku-deploy", peerRoku.deploy);
                 checkMenuItem("peer-roku-control", peerRoku.syncControl);
+                updatePeerRokuMenuLabels();
             }
         }
     } else {


### PR DESCRIPTION
This PR enhances the "Deploy to Peer Roku" menu item by dynamically appending the selected Peer Roku device's friendly name or IP address. Instead of a static "Deploy to Peer Roku", users will now see which specific device is targeted, e.g., "Deploy to Peer Roku (Roku Ultra 2024)".

Additionally, to prevent the menu from reverting to a bare IP or the default label on application startup while the network discovery runs, this PR introduces a local device cache. The app now immediately loads the previously discovered Roku devices on launch, providing a seamless user experience.

## Key Changes

### 1. Dynamic Menu Labels
*   **`src/menu/menuService.js`**: Added `updatePeerRokuMenuLabels()`. This function reads the configured Peer Roku and appends its `friendlyName` (or `ip` if manual) to the `Deploy to Peer Roku` menu template. It gracefully aborts if the `settings` object is not yet fully initialized.
*   **macOS Visual Updates**: Since macOS native menus cannot have their labels updated cleanly in-place post-creation, `src/main.js` explicitly invokes `createMenu()` when these labels change on macOS to ensure the UI updates instantly.

### 2. Discovered Devices Cache
*   **`src/helpers/settings.js`**: 
    *   Introduced `roku-devices.json` in the user data directory to cache the `discoveredDevices` Map.
    *   Added `loadDeviceCache()` which runs synchronously to populate the map at startup before SSDP starts.
    *   Added `saveDeviceCache()` which serializes and saves the map automatically when the SSDP network discovery loop finishes.
*   **`src/main.js`**: 
    *   Calls `loadDeviceCache()` prior to `loadSettings()` during startup so that `getRokuDeviceNameByIp()` returns the correct friendly names from the very first menu generation.
    *   Updates the Peer Roku menu labels as soon as `initRokuDeviceDiscovery()` resolves.

## Testing Instructions
1. Run the simulator.
2. Go to **Settings > Peer Roku** and select a discovered device on your network.
3. Observe the Application Menu under **Device**. The menu option should now read `Deploy to Peer Roku (Device Name)`.
4. Close and restart the simulator.
5. Open the **Device** menu immediately. The device name should appear right away without needing to wait 5 seconds for network discovery to finish.
