### PR TITLE
fix: force 200 status on CORS preflight responses

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -176,7 +176,18 @@ app.on("ready", () => {
         details.responseHeaders["Access-Control-Allow-Origin"] = ["*"];
         details.responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PUT, DELETE, HEAD, OPTIONS"];
         details.responseHeaders["Access-Control-Allow-Headers"] = ["*"];
-        callback({ responseHeaders: details.responseHeaders });
+        const response = { responseHeaders: details.responseHeaders };
+        // A cross-origin request with a non-simple header (e.g. roUrlTransfer's custom headers)
+        // makes Chromium send its own CORS preflight (an OPTIONS request) ahead of the real one.
+        // Real Roku hardware never does this, and most third-party servers were never built to
+        // answer it either — they reply with whatever they'd give any other unrecognized route
+        // (403/404/...), which fails the preflight on status alone before our injected
+        // Access-Control-Allow-* headers above are even considered. Force it to 200 so those
+        // headers can do their job.
+        if (details.method === "OPTIONS") {
+            response.statusLine = "HTTP/1.1 200 OK";
+        }
+        callback(response);
     });
     // Serve the app windows from the "app" scheme instead of file:// (see helpers/protocol.js).
     // Only the icons subdirectory of userData is exposed this way, not all of it — settings.json


### PR DESCRIPTION
## Summary
- After the Electron 43 upgrade (#337), app windows load from the `app://` origin instead of `file://`, so real browser CORS/preflight rules now apply where they didn't before (Electron granted `file://` universal cross-origin access).
- Requests with non-simple headers (e.g. `roUrlTransfer`'s custom headers in brs-engine) trigger a Chromium-generated `OPTIONS` preflight. Third-party servers that were never built to answer CORS preflights (e.g. S3-hosted images) reply with whatever status they'd give an unrecognized route (403/404), which fails the preflight on status alone — before the `Access-Control-Allow-*` headers already injected by the `onHeadersReceived` handler in `src/main.js` are even considered.
- Forces the preflight response's status line to `200 OK` when `details.method === "OPTIONS"`, so the already-injected CORS headers take effect — consistent with the existing rationale in that handler that real Roku hardware has no CORS concept at all.

## Test plan
- [x] `npm run lint`
- [x] `npm run prettier`
- [x] `npm test` (702 tests passing)
- [ ] Manually verify in the running app that cross-origin image loads (e.g. Trello S3-hosted channel poster/icon URLs) no longer log CORS preflight errors in devtools

🤖 Generated with [Claude Code](https://claude.com/claude-code)