### PR TITLE
feat: BrightScript-aware syntax coloring for the Editor console panel

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -328,6 +328,22 @@ completions, and formatting in `src/app/brightscript.js`. Monaco is bundled by
 `monaco-editor-webpack-plugin` with a deliberately trimmed feature list — enabling a Monaco feature
 means editing that plugin config in `build/webpack.app.config.js`.
 
+The console panel's syntax coloring is BrightScript-aware, not the `@lvcabral/terminal` package's
+generic Unix-console default: `src/app/consoleColors.js` exports `getBrsConsolePatterns(theme,
+COLOR_THEMES)`, a set of `{regex, color, type, priority}` rules passed to the terminal as
+`customPatterns`/`useDefaultPatterns: false`. `updateTerminal()` in `editor.js` HTML-escapes each
+line (`<`/`>` → entities, every space → `&nbsp;`) *before* the patterns run, so every pattern in
+`consoleColors.js` matches those literal entity strings, not raw `<`/`>`/space — and must stay
+narrowly scoped (no unbounded greedy/lazy quantifiers adjacent to each other), since the terminal
+resolves overlapping matches by start index first and priority only as a tie-breaker, so a wide
+pattern starting earlier always wins over a more specific one nested inside it regardless of
+priority. `updateTerminal()` calls `terminal.outputHTML()`, not `terminal.output()` — the latter's
+"colors disabled" path re-escapes its input as untrusted text, which double-escapes the entities
+already produced above. The `editor.options` checkbox is `disableConsoleColors` (disable-by-presence,
+not enable-by-presence) specifically so coloring defaults to on without needing a settings migration
+— `@lvcabral/electron-preferences` shallow-merges each settings group's persisted value over its
+default, so an enable-flag default could never turn itself on for an existing installation.
+
 ## Conventions
 
 - All `src/` files start with the standard copyright header block; match it in new files.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -167,6 +167,7 @@ ipcMain.on("eventName", (event, data) => { /* handler */ });
 #### Code Editor (`src/app/editor.js`)
 - **Monaco Integration**: Editor instance managed via `MonacoManager` from `src/app/monaco.js`
 - **Terminal Emulation**: Integrated console (`@lvcabral/terminal`) for BRS engine output and Micro Debugger commands
+- **Console Syntax Coloring (`src/app/consoleColors.js`)**: BrightScript-aware regex patterns (strings, numbers, booleans, `invalid`, component/function refs, device URIs, GUIDs, XML tags, timestamps, backtrace structure) passed to the terminal via `customPatterns`/`useDefaultPatterns: false`, replacing its generic Unix-console defaults; disabled per-user via the "Disable Console Log Coloring" Editor setting
 - **File Operations**: Save/load BRS source files, package creation for execution
 - **Theme Support**: Editor themes synchronized with main application theme
 - **Debug Features**: Breakpoint support, variable inspection, step debugging

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to this project will be documented in this file.
 
+<a name="v2.5.1"></a>
+
+## v2.5.1 - BrightScript-Aware Console Coloring
+
+This release gives the Editor console panel BrightScript-aware syntax coloring — strings, numbers, booleans, `invalid`, `<Component: ...>`/`<Function: ...>` references, `pkg:/`/`tmp:/` device URIs, GUIDs, XML tags, timestamps, backtrace structure, source comments, and `ERROR:`/`WARNING:`/`DEBUG:` labels are now colored distinctly instead of the generic Unix-console highlighting the terminal component shipped with by default. A new "Disable Console Log Coloring" option under Editor settings lets users opt back into plain text. Also fixes cross-origin channel content (e.g. S3-hosted posters/icons) failing to load after the Electron 43 upgrade.
+
+### New Features
+
+* Added BrightScript-aware syntax coloring to the Editor console panel, with a setting to disable it, by [@lvcabral](https://github.com/lvcabral) in [#339](https://github.com/lvcabral/brs-desktop/pull/339)
+
+### Bug Fixes
+
+* Forced 200 status on CORS preflight responses so cross-origin channel content loads correctly after the Electron 43 `app://` origin change by [@lvcabral](https://github.com/lvcabral) in [#338](https://github.com/lvcabral/brs-desktop/pull/338)
+
+### Dependency Bumps
+
+* Bump `@lvcabral/terminal` from 1.1.0 to 1.3.0 by [@lvcabral](https://github.com/lvcabral)
+
+Full Changelog: [v2.5.1]
+
 <a name="v2.5.0"></a>
 
 ## v2.5.0 - SG Home App and Peer Roku Discovery Persistence
@@ -832,6 +852,7 @@ Binaries are published at the engine library repository: <https://github.com/lvc
 
 [Changes][v0.5.0-app]
 
+[v2.5.1]: https://github.com/lvcabral/brs-desktop/compare/v2.5.0...v2.5.1
 [v2.5.0]: https://github.com/lvcabral/brs-desktop/compare/v2.4.0...v2.5.0
 [v2.4.0]: https://github.com/lvcabral/brs-desktop/compare/v2.3.0...v2.4.0
 [v2.3.0]: https://github.com/lvcabral/brs-desktop/compare/v2.2.0...v2.3.0

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -100,6 +100,7 @@ The IDE is implemented inside the **Editor Window** (`src/app/editor.html`), giv
 *   **Editor Controller (`src/app/editor.js`)**: Orchestrates file loading/saving and links the console to the simulation engine.
 *   **Monaco Engine Integration (`src/app/monaco.js`)**: Loads and configures Microsoft Monaco Editor.
 *   **BrightScript Language Support (`src/app/brightscript.js`)**: Defines custom syntax highlighting tokens (Monarch grammar rules), autocomplete tags for `roXXX` built-in components, and formatting/indentation configurations specifically tailored for BrightScript.
+*   **Console Syntax Coloring (`src/app/consoleColors.js`)**: BrightScript-aware regex pattern set (strings, numbers, booleans, component/function references, device URIs, GUIDs, timestamps, backtrace structure) fed to the `@lvcabral/terminal` package's `customPatterns` option, replacing its generic Unix-console defaults. Toggleable via a "Disable Console Log Coloring" Editor setting.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@electron/remote": "^2.0.9",
                 "@lvcabral/electron-preferences": "^3.0.1",
                 "@lvcabral/node-ssdp": "^4.0.4",
-                "@lvcabral/terminal": "^1.1.0",
+                "@lvcabral/terminal": "^1.3.0",
                 "busboy": "^1.6.0",
                 "custom-electron-titlebar": "^4.2.8",
                 "electron-about-window": "^1.14.0",
@@ -2317,9 +2317,9 @@
             "license": "BSD-3-Clause"
         },
         "node_modules/@lvcabral/terminal": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@lvcabral/terminal/-/terminal-1.1.0.tgz",
-            "integrity": "sha512-/gemdfXye7DSSedmuS35sbMfYaAIt+hISFQe1RwBQ9ZKgwscfKd+RzpZJyXCejNzqa0T77Yb/8GwZPhsUxWEdg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@lvcabral/terminal/-/terminal-1.3.0.tgz",
+            "integrity": "sha512-Cgz3LvZKXQS1XvDpNNx6wUCZQ0s89nW/jyaTwQqRg8Sx++2vRJAhdxpcRebBM3MOOcyZORGa3BqeNoTl865KZQ==",
             "license": "MIT",
             "bin": {
                 "terminal": "dist/web-terminal.js"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "brs-desktop",
     "productName": "BrightScript Simulator",
     "description": "Roku Device Simulation Tool",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "license": "MIT",
     "author": {
         "name": "Marcelo Lv Cabral",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
         "@electron/remote": "^2.0.9",
         "@lvcabral/electron-preferences": "^3.0.1",
         "@lvcabral/node-ssdp": "^4.0.4",
-        "@lvcabral/terminal": "^1.1.0",
+        "@lvcabral/terminal": "^1.3.0",
         "busboy": "^1.6.0",
         "custom-electron-titlebar": "^4.2.8",
         "electron-about-window": "^1.14.0",

--- a/src/app/consoleColors.js
+++ b/src/app/consoleColors.js
@@ -1,0 +1,95 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Simulation Desktop Application (https://github.com/lvcabral/brs-desktop)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Regex-to-color rules for BrightScript-aware console coloring, consumed by the `@lvcabral/terminal`
+// package's `customPatterns`/`useDefaultPatterns: false` option (see src/app/editor.js).
+//
+// IMPORTANT: by the time these patterns run, updateTerminal() has already HTML-escaped the line
+// (`<` -> `&lt;`, `>` -> `&gt;`) and replaced every space with `&nbsp;` — so patterns must match
+// those literal entity strings, not raw `<`, `>`, or a space character.
+//
+// Patterns are deliberately narrow (no greedy `.*`): the terminal package resolves overlapping
+// matches by start index first, priority second, so a wide/greedy pattern starting earlier would
+// win over a more specific one nested inside it regardless of priority.
+export function getBrsConsolePatterns(theme, colorThemes) {
+    const c = colorThemes[theme] || colorThemes.light;
+    return [
+        { regex: /"(?:[^"\\]|\\.)*"/g, color: c.string, type: "string", priority: 100 },
+        { regex: /'(?:[^'\\]|\\.)*'/g, color: c.string, type: "string", priority: 100 },
+        // Roku device URIs — pkg:/, tmp:/, cachefs:/, ext1:/, common:/, widget:/, complib:/ — with
+        // an optional trailing "(line[,col[-col]])" source-location suffix (as seen in error/backtrace
+        // text, e.g. "pkg:/source/editor_code.brs(3)"); the suffix is just as often absent for a
+        // plain resource path (e.g. "pkg:/images/logo.png").
+        {
+            regex: /\b(?:pkg|tmp|cachefs|ext1|common|widget|complib):\/[\w./-]+(?:\(\d+(?:,\d+(?:-\d+)?)?\))?/g,
+            color: c.path,
+            type: "location",
+            priority: 90,
+        },
+        // Web URLs. Stops at an "&nbsp;" (a real space in the original text) via lookahead rather
+        // than excluding "&" outright, so a literal "&" inside a query string still colors as part
+        // of the URL.
+        { regex: /https?:\/\/(?:(?!&nbsp;)[^\s<>"'])+/g, color: c.path, type: "location", priority: 88 },
+        // Standard 8-4-4-4-12 GUID/UUID, e.g. "3F2504E0-4F89-41D3-9A0C-0305E82C3301". A dedicated
+        // rule because the generic number/hex rules below can't cleanly match a run that mixes
+        // digits and letters across dash-separated groups.
+        { regex: /\b[0-9A-Fa-f]{8}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{4}-[0-9A-Fa-f]{12}\b/g, color: c.hex, type: "hex", priority: 85 },
+        // Component names may carry a namespace, e.g. "roSGNode:ContentNode" — [\w:.]+ covers that.
+        { regex: /&lt;Component:&nbsp;ro[\w:.]+&gt;/g, color: c.component, type: "component", priority: 85 },
+        { regex: /&lt;Function:&nbsp;\w+&gt;/g, color: c.info, type: "function", priority: 85 },
+        // Generic XML tags (open/close/self-closing), e.g. `<Config version="2">`, for the (rare)
+        // case an app logs raw XML. Lazily matches through the nearest "&gt;", so the whole tag
+        // (including any attributes) is one span — same treatment as, and same color as, the
+        // Component:/Function: rules above (whose tie at the same start index this rule's lower
+        // priority keeps losing).
+        { regex: /&lt;\/?[A-Za-z][\w:.-]*.*?&gt;/g, color: c.component, type: "structure", priority: 80 },
+        // A backtrace comment line, e.g. "005:&nbsp;&nbsp;&nbsp;&nbsp;'&nbsp;a&nbsp;comment" (the leading
+        // "NNN:" prefix, when present, is optional here so the match can also cover any indentation
+        // before the apostrophe). Higher priority than the plain "NNN:" structure rule below so a
+        // comment line wins the tie at the same start index instead of only the prefix being colored.
+        { regex: /^(?:\d{3}:(?:\*|&nbsp;))?(?:&nbsp;)*'.*/, color: c.comment, type: "comment", priority: 82 },
+        // Function/method call names, e.g. "second()", "createObject("roPath",1)",
+        // "GridView.RebuildRowList()" — matches only the identifier (optionally dotted, for object
+        // method calls) immediately followed by "(", via a lookahead that doesn't consume the "("
+        // itself. That keeps the match to just the call name: the arguments are left for the
+        // string/number/hex rules to color individually instead of being swallowed into one span.
+        // Covers backtrace frames too (e.g. "Function main() As Void" colors "main"), so no
+        // separate "Function ...(...)" rule is needed.
+        { regex: /\b[A-Za-z_]\w*(?:\.[A-Za-z_]\w*)*(?=\()/g, color: c.info, type: "function", priority: 80 },
+        { regex: /^#\d+(?:&nbsp;)+Function\b/, color: c.structure, type: "structure", priority: 80 },
+        { regex: /^\d{3}:(?:\*|&nbsp;)/, color: c.structure, type: "structure", priority: 80 },
+        { regex: /file\/line:/g, color: c.structure, type: "structure", priority: 70 },
+        { regex: /^BackTrace:/, color: c.structure, type: "structure", priority: 70 },
+        { regex: /BRIGHTSCRIPT:&nbsp;ERROR:/g, color: c.error, type: "error", priority: 75 },
+        { regex: /BRIGHTSCRIPT:&nbsp;WARNING:/g, color: c.warning, type: "warning", priority: 75 },
+        // A bare "ERROR:"/"WARNING:"/"DEBUG:" label leading a line (distinct from the
+        // "BRIGHTSCRIPT: ERROR:"/"BRIGHTSCRIPT: WARNING:" rules above, which only match that exact
+        // compound prefix anywhere in the text — these match apps that print their own log lines
+        // prefixed this way).
+        { regex: /^ERROR:/, color: c.error, type: "error", priority: 75 },
+        { regex: /^WARNING:/, color: c.warning, type: "warning", priority: 75 },
+        { regex: /^DEBUG:/, color: c.debugLabel, type: "structure", priority: 75 },
+        { regex: /\(&h[0-9A-Fa-f]+\)/g, color: c.hex, type: "hex", priority: 70 },
+        { regex: /\(v\d+(?:\.\d+)*\)/g, color: c.number, type: "number", priority: 75 },
+        // Timestamp prefix on structured log lines, e.g. "08-21 17:58:34.711 [scrpt.ctx.run.enter] ...".
+        { regex: /^\d{2}-\d{2}&nbsp;\d{2}:\d{2}:\d{2}\.\d{3}/, color: c.timestamp, type: "structure", priority: 65 },
+        // ISO 8601 dates, with or without milliseconds, "T" or space (already &nbsp;) separated.
+        {
+            regex: /\b\d{4}-\d{2}-\d{2}(?:T|&nbsp;)\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:?\d{2})?\b/g,
+            color: c.timestamp,
+            type: "structure",
+            priority: 65,
+        },
+        // Bracketed log tags, e.g. "[scrpt.ctx.run.enter]", "[beacon.report]".
+        { regex: /\[[\w.]+\]/g, color: c.tag, type: "structure", priority: 60 },
+        { regex: /\binvalid\b/g, color: c.invalid, type: "null", priority: 55 },
+        { regex: /\btrue\b/g, color: c.boolTrue, type: "boolean", priority: 55 },
+        { regex: /\bfalse\b/g, color: c.boolean, type: "boolean", priority: 55 },
+        { regex: /\b-?\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b|\bnan\b/g, color: c.number, type: "number", priority: 50 },
+    ];
+}

--- a/src/app/consoleColors.js
+++ b/src/app/consoleColors.js
@@ -26,7 +26,7 @@ export function getBrsConsolePatterns(theme, colorThemes) {
         // text, e.g. "pkg:/source/editor_code.brs(3)"); the suffix is just as often absent for a
         // plain resource path (e.g. "pkg:/images/logo.png").
         {
-            regex: /\b(?:pkg|tmp|cachefs|ext1|common|widget|complib):\/[\w./-]+(?:\(\d+(?:,\d+(?:-\d+)?)?\))?/g,
+            regex: /\b(?:pkg|tmp|cachefs|ext1|common|widget|complib):\/[\w./-]+(?:\(\d[\d,-]*\))?/g,
             color: c.path,
             type: "location",
             priority: 90,
@@ -46,8 +46,11 @@ export function getBrsConsolePatterns(theme, colorThemes) {
         // case an app logs raw XML. Lazily matches through the nearest "&gt;", so the whole tag
         // (including any attributes) is one span — same treatment as, and same color as, the
         // Component:/Function: rules above (whose tie at the same start index this rule's lower
-        // priority keeps losing).
-        { regex: /&lt;\/?[A-Za-z][\w:.-]*.*?&gt;/g, color: c.component, type: "structure", priority: 80 },
+        // priority keeps losing). No character class between the tag-name letter and the lazy
+        // `.*?` (SonarCloud S8786): two adjacent unbounded quantifiers matching overlapping content
+        // is what causes super-linear backtracking, and the lazy `.*?` alone already finds the
+        // right end.
+        { regex: /&lt;\/?[A-Za-z].*?&gt;/g, color: c.component, type: "structure", priority: 80 },
         // A backtrace comment line, e.g. "005:&nbsp;&nbsp;&nbsp;&nbsp;'&nbsp;a&nbsp;comment" (the leading
         // "NNN:" prefix, when present, is optional here so the match can also cover any indentation
         // before the apostrophe). Higher priority than the plain "NNN:" structure rule below so a
@@ -80,7 +83,7 @@ export function getBrsConsolePatterns(theme, colorThemes) {
         { regex: /^\d{2}-\d{2}&nbsp;\d{2}:\d{2}:\d{2}\.\d{3}/, color: c.timestamp, type: "structure", priority: 65 },
         // ISO 8601 dates, with or without milliseconds, "T" or space (already &nbsp;) separated.
         {
-            regex: /\b\d{4}-\d{2}-\d{2}(?:T|&nbsp;)\d{2}:\d{2}:\d{2}(?:\.\d{1,3})?(?:Z|[+-]\d{2}:?\d{2})?\b/g,
+            regex: /\b\d{4}-\d{2}-\d{2}(?:T|&nbsp;)\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-][\d:]{4,5})?\b/g,
             color: c.timestamp,
             type: "structure",
             priority: 65,

--- a/src/app/editor.js
+++ b/src/app/editor.js
@@ -7,9 +7,10 @@
  *--------------------------------------------------------------------------------------------*/
 import Codec from "json-url";
 import Mark from "mark.js";
-import WebTerminal from "@lvcabral/terminal";
+import WebTerminal, { COLOR_THEMES } from "@lvcabral/terminal";
 import { nanoid } from "nanoid";
 import { MonacoManager } from "./monaco";
+import { getBrsConsolePatterns } from "./consoleColors";
 import { EDITOR_CODE_BRS, BRS_HOME_APP_PATH } from "../constants";
 import Toastify from "toastify-js";
 import packageInfo from "../../package.json";
@@ -67,6 +68,18 @@ const commands = {
         terminal.output(`<br />BrightScript Simulation Engine v${brs.getVersion()}<br />`);
     },
 };
+
+// Initial theme/coloring state, read synchronously so the terminal construction and the
+// consoleBuffer replay below (both of which run before main()/DOMContentLoaded) use sensible
+// values instead of defaults. Kept in sync afterward by __setTheme() (see below).
+const initialPrefs = api.getPreferences();
+let initialTheme = initialPrefs?.simulator?.theme || "purple";
+if (initialTheme === "system") {
+    initialTheme = globalThis.matchMedia("(prefers-color-scheme:dark)")?.matches ? "dark" : "light";
+}
+let activeTheme = initialTheme === "light" ? "light" : "dark";
+let colorizeConsoleLogs = !initialPrefs?.editor?.options?.includes("disableConsoleColors");
+
 const terminal = new WebTerminal({
     welcome: `<span style='color: #2e71ff'>BrightScript Console - ${packageInfo.name} v${
         packageInfo.version
@@ -76,6 +89,14 @@ const terminal = new WebTerminal({
     prompt: prompt,
     ignoreBadCommand: true,
     autoFocus: false,
+    // contextualColors intentionally stays at its default (true) regardless of
+    // colorizeConsoleLogs: it also gates every other terminal.output() call in this file (the
+    // welcome banner above, the `<br />` messages elsewhere), which pass real HTML and need the
+    // "already has a tag, leave alone" path rather than the "no colors, escape everything" path.
+    // updateTerminal() below does its own explicit colorizeConsoleLogs gating instead.
+    colorTheme: activeTheme,
+    customPatterns: getBrsConsolePatterns(activeTheme, COLOR_THEMES),
+    useDefaultPatterns: false,
 });
 if (consoleBuffer?.length) {
     for (const entry of consoleBuffer) {
@@ -144,7 +165,10 @@ function main() {
         theme = __currentTheme();
     }
     const editorPrefs = preferences?.editor || {};
-    terminal.setColorTheme(theme === "light" ? "light" : "dark");
+    activeTheme = theme === "light" ? "light" : "dark";
+    colorizeConsoleLogs = !editorPrefs?.options?.includes("disableConsoleColors");
+    terminal.setColorTheme(activeTheme);
+    terminal.setCustomPatterns(getBrsConsolePatterns(activeTheme, COLOR_THEMES), false);
     editorManager = new MonacoManager(brsCodeField, theme, editorPrefs);
 
     // Force initial layout after a short delay to ensure container has dimensions
@@ -443,17 +467,33 @@ function updateTerminal(text, level = "print") {
         if (output.endsWith(`${prompt}&gt; `)) {
             output = output.slice(0, output.length - promptLen);
         }
-        output = output.replaceAll(" ", "&nbsp;");
-    } else if (level === "warning") {
-        output = terminal.colorize(output.replaceAll(" ", "&nbsp;"), "#d7ba7d");
-    } else if (level === "error") {
-        output = terminal.colors.brightRed(output.replaceAll(" ", "&nbsp;"));
     }
+    output = output.replaceAll(" ", "&nbsp;");
     const lines = output.trim().split(/\r?\n/);
-    for (const line of lines) {
-        terminal.output(line || "&zwnj;");
+    for (const rawLine of lines) {
+        let line = rawLine || "&zwnj;";
+        if (colorizeConsoleLogs) {
+            if (level === "print" || level === "beacon") {
+                line = terminal.highlight(line);
+            } else if (level === "debug") {
+                line = `<span style="color: ${COLOR_THEMES[activeTheme].debug}">${terminal.highlight(line)}</span>`;
+            } else if (level === "warning") {
+                line = terminal.colorize(line, COLOR_THEMES[activeTheme].warning);
+            } else if (level === "error") {
+                line = terminal.colorize(line, COLOR_THEMES[activeTheme].error);
+            }
+        }
+        // outputHTML(), not output(): `line` is already-escaped HTML/entities (built above and,
+        // when colorizeConsoleLogs is on, by highlight()/colorize()) either way. output()'s
+        // "colors disabled" path treats its input as raw untrusted text and HTML-escapes it,
+        // which would double-escape the &nbsp;/&lt;/&gt; entities already in `line` (e.g. &nbsp;
+        // -> &amp;nbsp;, rendering literally). outputHTML() never reprocesses its input, so it's
+        // correct for both the colorized and plain-text cases. resetCommand() replicates the one
+        // side effect output() also had (clearing/refocusing the command input line).
+        terminal.outputHTML(line);
+        terminal.resetCommand();
     }
-    
+
     if (!searchContainer.classList.contains("hidden") && searchInput.value.length > 0) {
         performSearch();
     }
@@ -1142,7 +1182,10 @@ globalThis.__setTheme = () => {
         const editorPrefs = preferences?.editor || {};
         editorManager.setIndentation(editorPrefs);
     }
-    terminal.setColorTheme(theme === "light" ? "light" : "dark");
+    activeTheme = theme === "light" ? "light" : "dark";
+    colorizeConsoleLogs = !preferences?.editor?.options?.includes("disableConsoleColors");
+    terminal.setColorTheme(activeTheme);
+    terminal.setCustomPatterns(getBrsConsolePatterns(activeTheme, COLOR_THEMES), false);
 };
 globalThis.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", __setTheme);
 api.onPreferencesUpdated(__setTheme);

--- a/src/helpers/settings.js
+++ b/src/helpers/settings.js
@@ -391,8 +391,11 @@ export function getSettings(window) {
                                             label: "Save Code Snippet on Run",
                                             value: "saveOnRun",
                                         },
+                                        {
+                                            label: "Disable Console Log Coloring",
+                                            value: "disableConsoleColors",
+                                        },
                                     ],
-                                    help: "Automatically save the current code snippet when running it (only applies to already saved snippets)",
                                 },
                             ],
                         },

--- a/test/unit/app/consoleColors.spec.js
+++ b/test/unit/app/consoleColors.spec.js
@@ -1,0 +1,267 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Simulation Desktop Application (https://github.com/lvcabral/brs-desktop)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { describe, it, expect } from "vitest";
+import { getBrsConsolePatterns } from "../../../src/app/consoleColors";
+
+// Distinct per-key colors so a test can assert exactly which rule matched.
+const FAKE_THEME = {
+    string: "#string",
+    path: "#path",
+    component: "#component",
+    info: "#info",
+    structure: "#structure",
+    error: "#error",
+    warning: "#warning",
+    hex: "#hex",
+    debug: "#debug",
+    null: "#null",
+    boolean: "#boolean",
+    number: "#number",
+    timestamp: "#timestamp",
+    tag: "#tag",
+    boolTrue: "#boolTrue",
+    invalid: "#invalid",
+    comment: "#comment",
+    debugLabel: "#debugLabel",
+};
+const COLOR_THEMES = { light: FAKE_THEME, dark: FAKE_THEME };
+
+// Mirrors @lvcabral/terminal's contextualColorize() overlap resolution (sort by start index,
+// then by priority descending; keep a match only if it doesn't overlap one already kept), so
+// these tests reflect what actually renders rather than raw, unresolved pattern matches.
+function colorFor(line) {
+    const patterns = getBrsConsolePatterns("light", COLOR_THEMES);
+    const matches = [];
+    for (const pattern of patterns) {
+        const flags = pattern.regex.flags.includes("g") ? pattern.regex.flags : pattern.regex.flags + "g";
+        const regex = new RegExp(pattern.regex.source, flags);
+        let match;
+        while ((match = regex.exec(line)) !== null) {
+            matches.push({
+                start: match.index,
+                end: match.index + match[0].length,
+                text: match[0],
+                color: pattern.color,
+                priority: pattern.priority,
+            });
+            if (match[0].length === 0) regex.lastIndex += 1;
+        }
+    }
+    matches.sort((a, b) => (a.start === b.start ? b.priority - a.priority : a.start - b.start));
+    const resolved = [];
+    let lastEnd = 0;
+    for (const match of matches) {
+        if (match.start >= lastEnd) {
+            resolved.push(match);
+            lastEnd = match.end;
+        }
+    }
+    return resolved;
+}
+
+describe("getBrsConsolePatterns", () => {
+    it("falls back to the light theme when the requested theme is missing", () => {
+        const patterns = getBrsConsolePatterns("nonexistent", COLOR_THEMES);
+        expect(patterns.find((p) => p.type === "string").color).toBe("#string");
+    });
+
+    it("colors a component with a namespaced name (roSGNode:ContentNode)", () => {
+        const matches = colorFor("&lt;Component:&nbsp;roSGNode:ContentNode&gt;&nbsp;=");
+        const hit = matches.find((m) => m.color === "#component");
+        expect(hit).toBeDefined();
+        expect(hit.text).toBe("&lt;Component:&nbsp;roSGNode:ContentNode&gt;");
+    });
+
+    it("still colors a plain component name (roAssociativeArray)", () => {
+        const matches = colorFor("&lt;Component:&nbsp;roAssociativeArray&gt;");
+        const hit = matches.find((m) => m.color === "#component");
+        expect(hit).toBeDefined();
+        expect(hit.text).toBe("&lt;Component:&nbsp;roAssociativeArray&gt;");
+    });
+
+    it("colors single-quoted text", () => {
+        const matches = colorFor("id&nbsp;'1748651461'");
+        const hit = matches.find((m) => m.color === "#string");
+        expect(hit).toBeDefined();
+        expect(hit.text).toBe("'1748651461'");
+    });
+
+    it("colors a bracketed log tag", () => {
+        const matches = colorFor("[scrpt.ctx.run.enter]&nbsp;UI:&nbsp;Entering");
+        const hit = matches.find((m) => m.color === "#tag" && m.text === "[scrpt.ctx.run.enter]");
+        expect(hit).toBeDefined();
+    });
+
+    it("colors the date/time prefix on a structured log line", () => {
+        const line = "08-21&nbsp;17:58:34.711&nbsp;[scrpt.ctx.run.enter]";
+        const matches = colorFor(line);
+        const hit = matches.find((m) => m.color === "#timestamp");
+        expect(hit).toBeDefined();
+        expect(hit.text).toBe("08-21&nbsp;17:58:34.711");
+        expect(hit.start).toBe(0);
+    });
+
+    it("colors a parenthesized version number", () => {
+        const matches = colorFor("brs-scenegraph&nbsp;(v0.5.1)&nbsp;from");
+        const hit = matches.find((m) => m.color === "#number" && m.text === "(v0.5.1)");
+        expect(hit).toBeDefined();
+    });
+
+    it("full structured log line: timestamp, bracket tag and single-quoted text all color", () => {
+        const line =
+            "08-21&nbsp;17:58:34.711&nbsp;[scrpt.ctx.run.enter]&nbsp;UI:&nbsp;Entering&nbsp;'BrightScript&nbsp;file:&nbsp;editor_code.brs',&nbsp;id&nbsp;'1748651461'";
+        const matches = colorFor(line);
+        expect(matches.some((m) => m.color === "#timestamp")).toBe(true);
+        expect(matches.some((m) => m.color === "#tag" && m.text === "[scrpt.ctx.run.enter]")).toBe(true);
+        expect(matches.some((m) => m.color === "#string" && m.text.includes("editor_code.brs"))).toBe(true);
+        expect(matches.some((m) => m.color === "#string" && m.text === "'1748651461'")).toBe(true);
+    });
+
+    it("colors true and false with distinct colors", () => {
+        const matches = colorFor("focusable:&nbsp;false,&nbsp;forwardDashQueryStringParams:&nbsp;true");
+        expect(matches.find((m) => m.text === "true").color).toBe("#boolTrue");
+        expect(matches.find((m) => m.text === "false").color).toBe("#boolean");
+    });
+
+    it("colors invalid as its own (purple) color, not null/boolean", () => {
+        const matches = colorFor("focusedChild:&nbsp;&lt;Component:&nbsp;roInvalid&gt;&nbsp;invalid");
+        const hit = matches.find((m) => m.text === "invalid" && m.color === "#invalid");
+        expect(hit).toBeDefined();
+    });
+
+    it("colors the function name in a backtrace frame signature", () => {
+        const line = "#3&nbsp;&nbsp;Function&nbsp;main()&nbsp;As&nbsp;Void";
+        const matches = colorFor(line);
+        expect(matches.some((m) => m.color === "#structure" && m.text === "#3&nbsp;&nbsp;Function")).toBe(true);
+        expect(matches.some((m) => m.color === "#info" && m.text === "main")).toBe(true);
+    });
+
+    it("colors a plain function call name", () => {
+        const matches = colorFor("result&nbsp;=&nbsp;second()");
+        const hit = matches.find((m) => m.color === "#info" && m.text === "second");
+        expect(hit).toBeDefined();
+    });
+
+    it("colors a dotted method call name (object.Method())", () => {
+        const matches = colorFor("GridView.RebuildRowList()&nbsp;failed");
+        const hit = matches.find((m) => m.color === "#info" && m.text === "GridView.RebuildRowList");
+        expect(hit).toBeDefined();
+    });
+
+    it("colors a call name but leaves its arguments individually colorable", () => {
+        const matches = colorFor('createObject("roPath",1)');
+        const callHit = matches.find((m) => m.color === "#info" && m.text === "createObject");
+        expect(callHit).toBeDefined();
+        const stringHit = matches.find((m) => m.color === "#string" && m.text === '"roPath"');
+        expect(stringHit).toBeDefined();
+        const numberHit = matches.find((m) => m.color === "#number" && m.text === "1");
+        expect(numberHit).toBeDefined();
+    });
+
+    it("does not treat a pkg: location's filename as a call name", () => {
+        const matches = colorFor("pkg:/source/editor_code.brs(3)");
+        expect(matches.some((m) => m.color === "#info")).toBe(false);
+        expect(matches.find((m) => m.color === "#path").text).toBe("pkg:/source/editor_code.brs(3)");
+    });
+
+    it("colors a source-listing comment line green, without recoloring a non-comment listing line", () => {
+        const commentLine = "005:&nbsp;&nbsp;&nbsp;&nbsp;'&nbsp;a&nbsp;comment";
+        const commentMatches = colorFor(commentLine);
+        const commentHit = commentMatches.find((m) => m.color === "#comment");
+        expect(commentHit).toBeDefined();
+        expect(commentHit.start).toBe(0);
+
+        const codeLine = "006:&nbsp;&nbsp;&nbsp;&nbsp;x&nbsp;=&nbsp;5";
+        const codeMatches = colorFor(codeLine);
+        expect(codeMatches.some((m) => m.color === "#comment")).toBe(false);
+        expect(codeMatches.some((m) => m.color === "#structure" && m.text === "006:&nbsp;")).toBe(true);
+    });
+
+    it("does not treat a mid-line quoted-string apostrophe as a comment", () => {
+        const matches = colorFor("id&nbsp;'1748651461'");
+        expect(matches.some((m) => m.color === "#comment")).toBe(false);
+    });
+
+    it("colors an ISO 8601 date with milliseconds", () => {
+        const matches = colorFor("timestamp:&nbsp;2026-08-21T22:21:12.058Z&nbsp;done");
+        const hit = matches.find((m) => m.color === "#timestamp" && m.text === "2026-08-21T22:21:12.058Z");
+        expect(hit).toBeDefined();
+    });
+
+    it("colors an ISO 8601 date without milliseconds", () => {
+        const matches = colorFor("timestamp:&nbsp;2026-08-21T22:21:12&nbsp;done");
+        const hit = matches.find((m) => m.color === "#timestamp" && m.text === "2026-08-21T22:21:12");
+        expect(hit).toBeDefined();
+    });
+
+    it("colors an XML open tag with an attribute (blue, like a component), and its matching close tag", () => {
+        const line = '&lt;Config&nbsp;version="2"&gt;value&lt;/Config&gt;';
+        const matches = colorFor(line);
+        expect(
+            matches.some((m) => m.color === "#component" && m.text === '&lt;Config&nbsp;version="2"&gt;')
+        ).toBe(true);
+        expect(matches.some((m) => m.color === "#component" && m.text === "&lt;/Config&gt;")).toBe(true);
+    });
+
+    it("colors a self-closing XML tag", () => {
+        const matches = colorFor("&lt;Node/&gt;");
+        const hit = matches.find((m) => m.color === "#component" && m.text === "&lt;Node/&gt;");
+        expect(hit).toBeDefined();
+    });
+
+    it("still colors <Component: ...> as a component, not a generic XML tag", () => {
+        const matches = colorFor("&lt;Component:&nbsp;roArray&gt;");
+        const hit = matches.find((m) => m.text === "&lt;Component:&nbsp;roArray&gt;");
+        expect(hit.color).toBe("#component");
+    });
+
+    it("colors a line-leading ERROR:/WARNING:/DEBUG: label", () => {
+        expect(colorFor("ERROR:&nbsp;something&nbsp;broke").find((m) => m.text === "ERROR:").color).toBe("#error");
+        expect(colorFor("WARNING:&nbsp;take&nbsp;care").find((m) => m.text === "WARNING:").color).toBe("#warning");
+        expect(colorFor("DEBUG:&nbsp;trace&nbsp;info").find((m) => m.text === "DEBUG:").color).toBe("#debugLabel");
+    });
+
+    it("does not double-match a bare label rule against a BRIGHTSCRIPT: ERROR: line", () => {
+        const matches = colorFor("BRIGHTSCRIPT:&nbsp;ERROR:&nbsp;bad&nbsp;thing");
+        expect(matches.filter((m) => m.color === "#error").length).toBe(1);
+        expect(matches.find((m) => m.color === "#error").text).toBe("BRIGHTSCRIPT:&nbsp;ERROR:");
+    });
+
+    it("colors a full GUID/UUID, not just the segment before the first dash", () => {
+        const matches = colorFor("id:&nbsp;3F2504E0-4F89-41D3-9A0C-0305E82C3301&nbsp;done");
+        const hit = matches.find((m) => m.color === "#hex" && m.text === "3F2504E0-4F89-41D3-9A0C-0305E82C3301");
+        expect(hit).toBeDefined();
+    });
+
+    it("colors a pkg:/ resource path with no trailing line-number suffix", () => {
+        const matches = colorFor("Loaded&nbsp;icon&nbsp;pkg:/images/logo.png&nbsp;ok");
+        const hit = matches.find((m) => m.color === "#path" && m.text === "pkg:/images/logo.png");
+        expect(hit).toBeDefined();
+    });
+
+    it("colors tmp:/ and other Roku device URI schemes", () => {
+        expect(colorFor("saved&nbsp;to&nbsp;tmp:/cache/file.tmp").find((m) => m.color === "#path").text).toBe(
+            "tmp:/cache/file.tmp"
+        );
+        expect(colorFor("reading&nbsp;from&nbsp;common:/certs/ca.pem").find((m) => m.color === "#path").text).toBe(
+            "common:/certs/ca.pem"
+        );
+    });
+
+    it("colors a plain http(s) URL", () => {
+        const matches = colorFor("from&nbsp;https://example.com/lib/brs-sg.js&nbsp;loaded");
+        const hit = matches.find((m) => m.color === "#path" && m.text === "https://example.com/lib/brs-sg.js");
+        expect(hit).toBeDefined();
+    });
+
+    it("colors an http(s) URL with a query string, without swallowing trailing text", () => {
+        const matches = colorFor("see&nbsp;https://example.com/x?a=1&b=2&nbsp;for&nbsp;details");
+        const hit = matches.find((m) => m.color === "#path" && m.text === "https://example.com/x?a=1&b=2");
+        expect(hit).toBeDefined();
+    });
+});


### PR DESCRIPTION
## Summary
- Adds BrightScript-aware syntax coloring to the Editor console panel (strings, numbers, booleans, `invalid`, `<Component: ...>`/`<Function: ...>` refs, `pkg:/`/`tmp:`/etc. device URIs, GUIDs, XML tags, timestamps, backtrace structure, source comments, and line-leading `ERROR:`/`WARNING:`/`DEBUG:` labels) instead of the generic Unix-console highlighting the terminal component shipped with by default.
- Adds a new "Disable Console Log Coloring" checkbox under Editor Options (unchecked by default, so coloring is on out of the box with no settings migration needed).
- Bumps `@lvcabral/terminal` to `^1.3.0`, which adds the `customPatterns`/`useDefaultPatterns` extension point this feature is built on, plus several new theme colors.

Closes #231

## Test plan
- [x] `npm test` — 731 passed
- [x] `npm run lint` — clean
- [x] `npm run prettier` — clean
- [x] `npm run build` — succeeds
- [x] Manually verified in the running app: coloring on/off toggle, light/dark theme switching, BrightScript errors/warnings/backtraces, component/array dumps, XML tag logging, GUIDs, and Roku device URIs

🤖 Generated with [Claude Code](https://claude.com/claude-code)