### PR TITLE
fix: reflect Origin/credentials in CORS headers instead of hardcoding wildcards

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -184,11 +184,21 @@ into `app/lib/` by CopyWebpackPlugin — bumping those packages changes what shi
   exposes the same entries), reads `Object.entries(localStorage)` out of it, and replays whatever
   isn't already present into the real window's `localStorage`, gated by a `LOCAL_STORAGE_MIGRATED_MARKER`
   file in `userData` so it doesn't pay for a hidden window on every future launch.
-- The same `onHeadersReceived` handler injects permissive CORS headers on every response — `file://`
-  got that behavior for free (Electron's universal file-URL access), `app://` doesn't, and real
-  channels routinely fetch cross-origin CDN content with no CORS headers of their own. Any
-  `Access-Control-Allow-*` header the origin server already sent must be cleared first — a duplicate
-  `Access-Control-Allow-Origin` is itself a CORS violation.
+- `src/helpers/cors.js`'s `enableCorsHeaders()` (registered on `session.defaultSession` from
+  `main.js`) injects permissive CORS headers on every response — `file://` got that behavior for
+  free (Electron's universal file-URL access), `app://` doesn't, and real channels routinely fetch
+  cross-origin CDN content with no CORS headers of their own. Any `Access-Control-Allow-*` header
+  the origin server already sent must be cleared first — a duplicate `Access-Control-Allow-Origin`
+  is itself a CORS violation. A request whose credentials mode is `"include"` (`RoURLTransfer` sets
+  `xhr.withCredentials` when a channel calls `roUrlTransfer.EnableCookies()`) makes the Fetch spec
+  reject the naive wildcard values: `Access-Control-Allow-Origin: "*"` is forbidden outright for a
+  credentialed response, and `Access-Control-Allow-Headers: "*"` stops meaning "anything" and is
+  read as the literal header name `"*"`. Both are handled the same way — reflect the real request's
+  `Origin` and `Access-Control-Request-Headers` back verbatim instead of hardcoding a wildcard,
+  which is valid for credentialed and non-credentialed requests alike and exactly as permissive.
+  `onHeadersReceived`'s details carry no request headers, so an `onBeforeSendHeaders` listener
+  captures `Origin`/`Access-Control-Request-Headers` per request id for `onHeadersReceived` to read
+  back, and `onCompleted`/`onErrorOccurred` (each fires exactly once per id) clean the map up.
 - **The main simulator window is always `BrowserWindow.fromId(1)`.** Roughly 35 call sites rely on this;
   it is created first in `createWindow()`. The editor window is opened as a child via
   `setWindowOpenHandler` intercepting `editor.html`, not via a separate `createWindow` call.

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -68,14 +68,25 @@ graph TD
 The **Main Process** (`src/main.js`) handles application lifecycle, creates browser windows, reads/writes preferences, and launches background servers mimicking Roku hardware services.
 
 *   **Window Management (`src/helpers/window.js`)**: Creates the primary simulator window (`index.html`) and auxiliary windows like the **Code Editor & Console** (`editor.html`). Saves window dimensions and states across restarts.
-*   **Security & SharedArrayBuffer Support**: By default, Electron disables certain cross-origin features. To allow `brs-engine` to run in multithreaded environments with `SharedArrayBuffer`, the Main Process registers response headers to implement **Cross-Origin Opener Policy (COOP)** and **Cross-Origin Embedder Policy (COEP)**:
+*   **Security & SharedArrayBuffer Support**: By default, Electron disables certain cross-origin features. To allow `brs-engine` to run in multithreaded environments with `SharedArrayBuffer`, `src/helpers/cors.js`'s `enableCorsHeaders()` (registered on `session.defaultSession` from `main.js`) sets **Cross-Origin Opener Policy (COOP)** and **Cross-Origin Embedder Policy (COEP)** response headers, and also stamps permissive `Access-Control-Allow-*` headers on every response so real channels can fetch cross-origin CDN content the way they would with no CORS at all on physical Roku hardware. A credentialed request (`RoURLTransfer`'s `xhr.withCredentials`, set when a channel calls `roUrlTransfer.EnableCookies()`) makes the Fetch spec reject a literal wildcard for `Access-Control-Allow-Origin`/`-Headers`, so those are reflected back from the real request's `Origin` / `Access-Control-Request-Headers` instead — captured in an `onBeforeSendHeaders` listener (per request id, since `onHeadersReceived`'s details carry no request headers) and cleaned up on `onCompleted`/`onErrorOccurred`. An `OPTIONS` preflight's status line is also forced to `200 OK`, since third-party servers were never built to answer Chromium's synthetic preflight and would otherwise fail it on status alone before the injected headers are considered:
     ```javascript
-    session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-        details.responseHeaders["Cross-Origin-Opener-Policy"] = ["same-origin"];
-        details.responseHeaders["Cross-Origin-Embedder-Policy"] = ["require-corp"];
-        details.responseHeaders["Cross-Origin-Resource-Policy"] = ["cross-origin"];
-        callback({ responseHeaders: details.responseHeaders });
-    });
+    // src/helpers/cors.js
+    export function buildCorsHeaders(details, pending = {}) {
+        const responseHeaders = details.responseHeaders;
+        responseHeaders["Cross-Origin-Opener-Policy"] = ["same-origin"];
+        responseHeaders["Cross-Origin-Embedder-Policy"] = ["require-corp"];
+        responseHeaders["Cross-Origin-Resource-Policy"] = ["cross-origin"];
+        // ...strip any Access-Control-Allow-* the origin server already sent...
+        responseHeaders["Access-Control-Allow-Origin"] = [pending.origin || "*"];
+        responseHeaders["Access-Control-Allow-Credentials"] = ["true"];
+        responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PUT, DELETE, HEAD, OPTIONS"];
+        responseHeaders["Access-Control-Allow-Headers"] = [pending.requestedHeaders || "*"];
+        const response = { responseHeaders };
+        if (details.method === "OPTIONS") {
+            response.statusLine = "HTTP/1.1 200 OK";
+        }
+        return response;
+    }
     ```
 *   **Settings Persistence (`src/helpers/settings.js`)**: Uses `@lvcabral/electron-preferences` to handle user-customizable settings (display resolution, overscan mode, audio mute, localization, remote controller key assignments, and remote services ports).
 

--- a/src/helpers/cors.js
+++ b/src/helpers/cors.js
@@ -1,0 +1,117 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Simulation Desktop Application (https://github.com/lvcabral/brs-desktop)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Real Roku hardware has no CORS concept; app:// is a real origin (unlike file://, which grants
+// documents universal cross-origin XHR access), so this restores that behavior by stamping every
+// response with permissive Access-Control-Allow-* headers.
+//
+// A request whose credentials mode is "include" (brs-engine's RoURLTransfer sets
+// `xhr.withCredentials = true` when a channel calls roUrlTransfer.EnableCookies()) makes the
+// Fetch spec reject two of the values this file used to hardcode:
+//   - Access-Control-Allow-Origin: "*" is forbidden outright for a credentialed response; the
+//     origin must be echoed back explicitly.
+//   - Access-Control-Allow-Headers: "*" is read as the literal header name "*" rather than a
+//     wildcard once credentials are involved, so a credentialed request carrying a custom header
+//     (e.g. the case PR #338 already special-cases for the OPTIONS status) would still fail
+//     preflight.
+// Reflecting the real request's Origin and Access-Control-Request-Headers back is valid for both
+// credentialed and non-credentialed requests, and is exactly as permissive as the wildcard was —
+// so it keeps this file's "allow everything" intent without tripping the spec's guard rail.
+//
+// onHeadersReceived's details carry no request headers (only onBeforeSendHeaders does), so a
+// request's Origin/Access-Control-Request-Headers are captured there and stashed by request id
+// for onHeadersReceived to read back. onCompleted/onErrorOccurred each fire exactly once per
+// request id and are what clean the map up — without them it would grow for the life of the app.
+
+/**
+ * Build the onHeadersReceived callback payload for one response.
+ * @param {import("electron").OnHeadersReceivedListenerDetails} details - The response details
+ * @param {{origin?: string, requestedHeaders?: string}} [pending] - Origin/requested-headers captured
+ *   for this request's id by the onBeforeSendHeaders listener, if any
+ * @returns {{responseHeaders: Record<string, string[]>, statusLine?: string}} - The callback payload
+ */
+export function buildCorsHeaders(details, pending = {}) {
+    const responseHeaders = details.responseHeaders;
+    responseHeaders["Cross-Origin-Opener-Policy"] = ["same-origin"];
+    responseHeaders["Cross-Origin-Embedder-Policy"] = ["require-corp"];
+    responseHeaders["Cross-Origin-Resource-Policy"] = ["cross-origin"];
+    // Clear any existing Access-Control-Allow-* first — a server that sends its own gets a
+    // duplicated header (e.g. "*, *" or "true, true"), which is a CORS error itself.
+    for (const key of Object.keys(responseHeaders)) {
+        if (key.toLowerCase().startsWith("access-control-allow-")) {
+            delete responseHeaders[key];
+        }
+    }
+    responseHeaders["Access-Control-Allow-Origin"] = [pending.origin || "*"];
+    // Every requester sharing this session (main + editor windows both use session.defaultSession,
+    // see helpers/window.js) gets credentialed cross-origin reads unconditionally — no allowlist.
+    // That is a deliberate extension of this file's "real Roku hardware has no CORS concept"
+    // stance to credentialed requests too, not an oversight: tightening it would mean deciding
+    // which origins a sideloaded channel's roUrlTransfer.EnableCookies() calls should still be
+    // allowed to reach, which this app has never restricted for non-credentialed requests either.
+    responseHeaders["Access-Control-Allow-Credentials"] = ["true"];
+    responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PUT, DELETE, HEAD, OPTIONS"];
+    responseHeaders["Access-Control-Allow-Headers"] = [pending.requestedHeaders || "*"];
+    const response = { responseHeaders };
+    // A cross-origin request with a non-simple header (e.g. roUrlTransfer's custom headers)
+    // makes Chromium send its own CORS preflight (an OPTIONS request) ahead of the real one.
+    // Real Roku hardware never does this, and most third-party servers were never built to
+    // answer it either — they reply with whatever they'd give any other unrecognized route
+    // (403/404/...), which fails the preflight on status alone before our injected
+    // Access-Control-Allow-* headers above are even considered. Force it to 200 so those
+    // headers can do their job.
+    if (details.method === "OPTIONS") {
+        response.statusLine = "HTTP/1.1 200 OK";
+    }
+    return response;
+}
+
+// Request header casing isn't guaranteed, so this collects both values (Origin and
+// Access-Control-Request-Headers) in a single pass over the header names. Returns null for the
+// common case (same-origin/non-preflight traffic, the majority of requests) so the caller has
+// nothing worth tracking for that request's id.
+function findOriginAndRequestedHeaders(requestHeaders) {
+    const pending = {};
+    for (const key of Object.keys(requestHeaders)) {
+        const lower = key.toLowerCase();
+        if (lower === "origin") {
+            pending.origin = requestHeaders[key];
+        } else if (lower === "access-control-request-headers") {
+            pending.requestedHeaders = requestHeaders[key];
+        }
+    }
+    return pending.origin || pending.requestedHeaders ? pending : null;
+}
+
+/**
+ * Register the CORS/COOP/COEP header injection on a session, enabling SharedArrayBuffer and
+ * cross-origin requests (including credentialed ones) the same way real Roku hardware allows them.
+ *
+ * Claims 4 webRequest listener slots (onBeforeSendHeaders, onHeadersReceived, onCompleted,
+ * onErrorOccurred) on `appSession`. Electron allows only one listener per event type per session —
+ * registering any of these same event types elsewhere on the same session silently replaces this
+ * one (or vice versa) with no error, breaking CORS/credentialed requests app-wide. Route any future
+ * use of these events through this function instead of registering a second listener.
+ * @param {import("electron").Session} appSession - The session to instrument, typically session.defaultSession
+ */
+export function enableCorsHeaders(appSession) {
+    const pendingByRequestId = new Map();
+    appSession.webRequest.onBeforeSendHeaders((details, callback) => {
+        const pending = findOriginAndRequestedHeaders(details.requestHeaders);
+        if (pending) {
+            pendingByRequestId.set(details.id, pending);
+        }
+        callback({ requestHeaders: details.requestHeaders });
+    });
+    appSession.webRequest.onHeadersReceived((details, callback) => {
+        callback(buildCorsHeaders(details, pendingByRequestId.get(details.id)));
+    });
+    const forgetRequest = (details) => pendingByRequestId.delete(details.id);
+    appSession.webRequest.onCompleted(forgetRequest);
+    appSession.webRequest.onErrorOccurred(forgetRequest);
+}

--- a/src/main.js
+++ b/src/main.js
@@ -12,6 +12,7 @@ import fs from "node:fs";
 import { app, screen, BrowserWindow, session } from "electron";
 import { DateTime } from "luxon";
 import { registerAppScheme, enableAppProtocol, appUrl } from "./helpers/protocol";
+import { enableCorsHeaders } from "./helpers/cors";
 import { setPassword, setPort, enableInstaller } from "./server/installer";
 import { initECP, enableECP } from "./server/ecp";
 import { enableTelnet } from "./server/telnet";
@@ -160,35 +161,9 @@ app.on("ready", () => {
         deviceInfo: deviceInfo,
     };
     updateAppList();
-    // Add CORS headers to enable SharedArrayBuffer and cross-origin requests
-    session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-        details.responseHeaders["Cross-Origin-Opener-Policy"] = ["same-origin"];
-        details.responseHeaders["Cross-Origin-Embedder-Policy"] = ["require-corp"];
-        details.responseHeaders["Cross-Origin-Resource-Policy"] = ["cross-origin"];
-        // Real Roku hardware has no CORS concept; app:// is a real origin (unlike file://), so
-        // this restores that behavior. Clear any existing Access-Control-Allow-* first — a server
-        // that sends its own gets a duplicated header (e.g. "*, *"), which is a CORS error itself.
-        for (const key of Object.keys(details.responseHeaders)) {
-            if (key.toLowerCase().startsWith("access-control-allow-")) {
-                delete details.responseHeaders[key];
-            }
-        }
-        details.responseHeaders["Access-Control-Allow-Origin"] = ["*"];
-        details.responseHeaders["Access-Control-Allow-Methods"] = ["GET, POST, PUT, DELETE, HEAD, OPTIONS"];
-        details.responseHeaders["Access-Control-Allow-Headers"] = ["*"];
-        const response = { responseHeaders: details.responseHeaders };
-        // A cross-origin request with a non-simple header (e.g. roUrlTransfer's custom headers)
-        // makes Chromium send its own CORS preflight (an OPTIONS request) ahead of the real one.
-        // Real Roku hardware never does this, and most third-party servers were never built to
-        // answer it either — they reply with whatever they'd give any other unrecognized route
-        // (403/404/...), which fails the preflight on status alone before our injected
-        // Access-Control-Allow-* headers above are even considered. Force it to 200 so those
-        // headers can do their job.
-        if (details.method === "OPTIONS") {
-            response.statusLine = "HTTP/1.1 200 OK";
-        }
-        callback(response);
-    });
+    // Add CORS headers to enable SharedArrayBuffer and cross-origin (including credentialed)
+    // requests — see helpers/cors.js for the full rationale.
+    enableCorsHeaders(session.defaultSession);
     // Serve the app windows from the "app" scheme instead of file:// (see helpers/protocol.js).
     // Only the icons subdirectory of userData is exposed this way, not all of it — settings.json
     // and friends live in userData too and must stay unreachable from the renderer.

--- a/test/mocks/electron.js
+++ b/test/mocks/electron.js
@@ -303,7 +303,12 @@ export const shell = {
 
 export const session = {
     defaultSession: {
-        webRequest: { onHeadersReceived: vi.fn() },
+        webRequest: {
+            onBeforeSendHeaders: vi.fn(),
+            onHeadersReceived: vi.fn(),
+            onCompleted: vi.fn(),
+            onErrorOccurred: vi.fn(),
+        },
         clearCache: vi.fn(() => Promise.resolve()),
     },
 };

--- a/test/unit/helpers/cors.spec.js
+++ b/test/unit/helpers/cors.spec.js
@@ -1,0 +1,125 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Simulation Desktop Application (https://github.com/lvcabral/brs-desktop)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import { describe, it, expect, beforeEach } from "vitest";
+import { session } from "../../mocks/electron.js";
+import { buildCorsHeaders, enableCorsHeaders } from "../../../src/helpers/cors";
+
+function makeDetails(overrides = {}) {
+    return {
+        id: 1,
+        method: "GET",
+        responseHeaders: {},
+        ...overrides,
+    };
+}
+
+describe("buildCorsHeaders", () => {
+    it("reflects the tracked Origin instead of a wildcard, and allows credentials", () => {
+        const { responseHeaders } = buildCorsHeaders(makeDetails(), { origin: "https://channel.example" });
+        expect(responseHeaders["Access-Control-Allow-Origin"]).toEqual(["https://channel.example"]);
+        expect(responseHeaders["Access-Control-Allow-Credentials"]).toEqual(["true"]);
+    });
+
+    it("falls back to a wildcard origin when no Origin was tracked for the request", () => {
+        const { responseHeaders } = buildCorsHeaders(makeDetails());
+        expect(responseHeaders["Access-Control-Allow-Origin"]).toEqual(["*"]);
+    });
+
+    it("forces a 200 status line on OPTIONS preflight requests, and echoes the requested headers back", () => {
+        const details = makeDetails({ method: "OPTIONS" });
+        const result = buildCorsHeaders(details, {
+            origin: "https://channel.example",
+            requestedHeaders: "x-custom-header",
+        });
+        expect(result.statusLine).toBe("HTTP/1.1 200 OK");
+        expect(result.responseHeaders["Access-Control-Allow-Headers"]).toEqual(["x-custom-header"]);
+    });
+
+    it("does not force a status line on non-OPTIONS requests", () => {
+        const result = buildCorsHeaders(makeDetails());
+        expect(result.statusLine).toBeUndefined();
+    });
+
+    it("falls back to a wildcard Access-Control-Allow-Headers when no headers were requested", () => {
+        const { responseHeaders } = buildCorsHeaders(makeDetails({ method: "OPTIONS" }));
+        expect(responseHeaders["Access-Control-Allow-Headers"]).toEqual(["*"]);
+    });
+
+    it("strips a server's own Access-Control-Allow-* headers instead of duplicating them", () => {
+        const details = makeDetails({
+            responseHeaders: {
+                "Access-Control-Allow-Origin": ["https://someone-else.example"],
+                "Access-Control-Allow-Credentials": ["false"],
+            },
+        });
+        const { responseHeaders } = buildCorsHeaders(details, { origin: "https://channel.example" });
+        expect(responseHeaders["Access-Control-Allow-Origin"]).toEqual(["https://channel.example"]);
+        expect(responseHeaders["Access-Control-Allow-Credentials"]).toEqual(["true"]);
+    });
+
+    it("always sets the COOP/COEP/CORP isolation headers", () => {
+        const { responseHeaders } = buildCorsHeaders(makeDetails());
+        expect(responseHeaders["Cross-Origin-Opener-Policy"]).toEqual(["same-origin"]);
+        expect(responseHeaders["Cross-Origin-Embedder-Policy"]).toEqual(["require-corp"]);
+        expect(responseHeaders["Cross-Origin-Resource-Policy"]).toEqual(["cross-origin"]);
+    });
+});
+
+describe("enableCorsHeaders", () => {
+    let webRequest;
+    let handlers;
+
+    beforeEach(() => {
+        webRequest = session.defaultSession.webRequest;
+        webRequest.onBeforeSendHeaders.mockClear();
+        webRequest.onHeadersReceived.mockClear();
+        webRequest.onCompleted.mockClear();
+        webRequest.onErrorOccurred.mockClear();
+        enableCorsHeaders(session.defaultSession);
+        handlers = {
+            onBeforeSendHeaders: webRequest.onBeforeSendHeaders.mock.calls[0][0],
+            onHeadersReceived: webRequest.onHeadersReceived.mock.calls[0][0],
+            onCompleted: webRequest.onCompleted.mock.calls[0][0],
+            onErrorOccurred: webRequest.onErrorOccurred.mock.calls[0][0],
+        };
+    });
+
+    it("registers listeners for the full request lifecycle", () => {
+        expect(webRequest.onBeforeSendHeaders).toHaveBeenCalledTimes(1);
+        expect(webRequest.onHeadersReceived).toHaveBeenCalledTimes(1);
+        expect(webRequest.onCompleted).toHaveBeenCalledTimes(1);
+        expect(webRequest.onErrorOccurred).toHaveBeenCalledTimes(1);
+    });
+
+    it("tracks a request's Origin from onBeforeSendHeaders and uses it in onHeadersReceived", () => {
+        handlers.onBeforeSendHeaders({ id: 42, requestHeaders: { Origin: "https://channel.example" } }, () => {});
+        let response;
+        handlers.onHeadersReceived(makeDetails({ id: 42 }), (r) => (response = r));
+        expect(response.responseHeaders["Access-Control-Allow-Origin"]).toEqual(["https://channel.example"]);
+    });
+
+    it("forgets a request's tracked data once it completes or errors", () => {
+        handlers.onBeforeSendHeaders({ id: 1, requestHeaders: { Origin: "https://a.example" } }, () => {});
+        handlers.onCompleted({ id: 1 });
+        let response;
+        handlers.onHeadersReceived(makeDetails({ id: 1 }), (r) => (response = r));
+        expect(response.responseHeaders["Access-Control-Allow-Origin"]).toEqual(["*"]);
+
+        handlers.onBeforeSendHeaders({ id: 2, requestHeaders: { Origin: "https://b.example" } }, () => {});
+        handlers.onErrorOccurred({ id: 2 });
+        handlers.onHeadersReceived(makeDetails({ id: 2 }), (r) => (response = r));
+        expect(response.responseHeaders["Access-Control-Allow-Origin"]).toEqual(["*"]);
+    });
+
+    it("does not track a request that carries no Origin or Access-Control-Request-Headers", () => {
+        handlers.onBeforeSendHeaders({ id: 7, requestHeaders: {} }, () => {});
+        let response;
+        handlers.onHeadersReceived(makeDetails({ id: 7 }), (r) => (response = r));
+        expect(response.responseHeaders["Access-Control-Allow-Origin"]).toEqual(["*"]);
+    });
+});


### PR DESCRIPTION
## Summary
- A user reported channel data-load failures with `Access-Control-Allow-Origin' header ... must not be the wildcard '*' when the request's credentials mode is 'include'` after the Electron 43 upgrade (#337/#338 moved app windows from `file://` to the CORS-enforcing `app://` origin).
- `RoURLTransfer` sets `xhr.withCredentials = true` when a channel calls `roUrlTransfer.EnableCookies()`; the Fetch spec forbids `Access-Control-Allow-Origin: "*"` on a credentialed response, so those requests were blocked outright by the browser before any data reached BrightScript. `Access-Control-Allow-Headers: "*"` has the same problem for credentialed preflights carrying custom headers.
- Extracted the header injection out of `src/main.js` into a new `src/helpers/cors.js`, which now reflects the real request's `Origin` and `Access-Control-Request-Headers` back instead of hardcoding wildcards — valid for both credentialed and non-credentialed requests, and just as permissive as the previous wildcard.
- Origin/requested-headers are captured per request id via `onBeforeSendHeaders` (since `onHeadersReceived`'s details carry no request headers) and cleaned up via `onCompleted`/`onErrorOccurred`.
- Updated `.claude/CLAUDE.md` and `GEMINI.md` to describe the new module and credentialed-request handling.

## Test plan
- [x] `npm test` — 742 passed, including a new `test/unit/helpers/cors.spec.js` covering the credentials fix, the preflight-headers fix, dedup of a server's own CORS headers, and the request-tracking Map lifecycle.
- [x] `npm run lint`
- [x] `npm run prettier`
- [ ] Manual: reproduce against the original (redacted) URL from the bug report to confirm the console error is gone and data loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Un1DZT4Lva7LN8ut2BxHoR