### PR TITLE
fix: persist last-used folder for file dialogs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "brs-desktop",
-    "version": "2.5.0",
+    "version": "2.5.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "brs-desktop",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "hasInstallScript": true,
             "license": "MIT",
             "dependencies": {

--- a/src/constants.js
+++ b/src/constants.js
@@ -37,6 +37,11 @@ export const EDITOR_CODE_BRS = "editor_code.brs";
 // migrate from the pre-2.5.0 file:// origin.
 export const LOCAL_STORAGE_MIGRATED_MARKER = "local-storage-migrated";
 
+// JSON file in userData that remembers the last folder each file dialog navigated to,
+// so reopening a dialog starts where the user left off (Electron 43+ stopped doing this
+// automatically).
+export const DIALOG_STATE_FILE = "dialog-state.json";
+
 // Maximum package size in MB
 export const MAX_PACKAGE_SIZE_MB = 7;
 

--- a/src/helpers/dialog.js
+++ b/src/helpers/dialog.js
@@ -107,4 +107,3 @@ function getFileFilter(description, extensions) {
         { name: "All Files", extensions: ["*"] },
     ];
 }
-

--- a/src/helpers/dialog.js
+++ b/src/helpers/dialog.js
@@ -5,17 +5,48 @@
  *
  *  Licensed under the MIT License. See LICENSE in the repository root for license information.
  *--------------------------------------------------------------------------------------------*/
-import { BrowserWindow, dialog } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import { loadFile } from "./files";
+import { readJsonFile, writeJsonFile } from "./util";
+import { DIALOG_STATE_FILE } from "../constants";
+import path from "node:path";
+
+// In-memory cache; lazily loaded on first use, flushed on every update.
+let dialogState;
+
+/**
+ * Loads the persisted dialog state from disk (once per process).
+ * @returns {object} - The dialog state, with `openDir` and `saveDir` keys
+ */
+function loadState() {
+    if (!dialogState) {
+        const filePath = path.join(app.getPath("userData"), DIALOG_STATE_FILE);
+        dialogState = readJsonFile(filePath) ?? {};
+    }
+    return dialogState;
+}
+
+/**
+ * Persists the current in-memory dialog state to disk.
+ */
+function saveState() {
+    const filePath = path.join(app.getPath("userData"), DIALOG_STATE_FILE);
+    writeJsonFile(filePath, dialogState);
+}
+
 /*
  * Show open dialog to open an app package .zip or .bpk file.
  */
 export function openChannelPackage() {
+    const state = loadState();
     const opts = {
         title: "Select an App package file.",
         filters: getFileFilter("App Packages", ["zip", "bpk"]),
         properties: ["openFile"],
     };
+    if (state.openDir) {
+        opts.defaultPath = state.openDir;
+    }
     const window = BrowserWindow.fromId(1);
     dialog
         .showOpenDialog(window, opts)
@@ -23,6 +54,8 @@ export function openChannelPackage() {
             if (result.canceled) {
                 return;
             }
+            state.openDir = path.dirname(result.filePaths[0]);
+            saveState();
             loadFile(result.filePaths);
         })
         .catch((err) => {
@@ -31,6 +64,7 @@ export function openChannelPackage() {
 }
 
 export function saveScreenshot() {
+    const state = loadState();
     const opts = {
         title: "Save the Screenshot as",
         filters: [
@@ -38,6 +72,9 @@ export function saveScreenshot() {
             { name: "JPEG Image", extensions: ["jpg", "jpeg"] },
         ],
     };
+    if (state.saveDir) {
+        opts.defaultPath = state.saveDir;
+    }
     const window = BrowserWindow.fromId(1);
     dialog
         .showSaveDialog(window, opts)
@@ -45,11 +82,21 @@ export function saveScreenshot() {
             if (result.canceled) {
                 return;
             }
+            state.saveDir = path.dirname(result.filePath);
+            saveState();
             window.webContents.send("saveScreenshot", result.filePath);
         })
         .catch((err) => {
             console.error(err);
         });
+}
+
+/**
+ * Clears the in-memory dialog state cache so the next call to `loadState()` re-reads from disk.
+ * Exported only for testing.
+ */
+export function __resetDialogState() {
+    dialogState = undefined;
 }
 
 // Helper functions
@@ -60,3 +107,4 @@ function getFileFilter(description, extensions) {
         { name: "All Files", extensions: ["*"] },
     ];
 }
+

--- a/test/unit/helpers/dialog.spec.js
+++ b/test/unit/helpers/dialog.spec.js
@@ -1,0 +1,152 @@
+/*---------------------------------------------------------------------------------------------
+ *  BrightScript Simulation Desktop Application (https://github.com/lvcabral/brs-desktop)
+ *
+ *  Copyright (c) 2019-2026 Marcelo Lv Cabral. All Rights Reserved.
+ *
+ *  Licensed under the MIT License. See LICENSE in the repository root for license information.
+ *--------------------------------------------------------------------------------------------*/
+import fs from "node:fs";
+import path from "node:path";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { dialog, __registerWindow, createFakeWindow } from "../../mocks/electron";
+import { DIALOG_STATE_FILE } from "../../../src/constants";
+import { getTestUserData } from "../../setup/global";
+import { openChannelPackage, saveScreenshot, __resetDialogState } from "../../../src/helpers/dialog";
+
+// The module under test imports `loadFile` from files.js, which registers ipcMain handlers at
+// module-evaluation time. We don't want those side-effects here, so mock the module.
+vi.mock("../../../src/helpers/files", () => ({
+    loadFile: vi.fn(),
+}));
+
+describe("dialog — last-used folder persistence", () => {
+    let fakeWindow;
+    let stateFile;
+
+    beforeEach(() => {
+        fakeWindow = createFakeWindow(1);
+        __registerWindow(fakeWindow);
+        stateFile = path.join(getTestUserData(), DIALOG_STATE_FILE);
+        // Remove any leftover state file from a previous test
+        try {
+            fs.unlinkSync(stateFile);
+        } catch {
+            // ignore
+        }
+        __resetDialogState();
+        dialog.showOpenDialog.mockReset();
+        dialog.showSaveDialog.mockReset();
+    });
+
+    describe("openChannelPackage", () => {
+        it("passes no defaultPath when no state file exists", async () => {
+            dialog.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+            openChannelPackage();
+            await vi.waitFor(() => expect(dialog.showOpenDialog).toHaveBeenCalled());
+            const opts = dialog.showOpenDialog.mock.calls[0][1];
+            expect(opts.defaultPath).toBeUndefined();
+        });
+
+        it("saves the selected folder and passes it as defaultPath on the next call", async () => {
+            // First call: user selects a file
+            dialog.showOpenDialog.mockResolvedValue({
+                canceled: false,
+                filePaths: ["/Users/test/channels/myapp.zip"],
+            });
+            openChannelPackage();
+            // Wait for the promise chain to settle
+            await vi.waitFor(() => expect(fs.existsSync(stateFile)).toBe(true));
+
+            // Verify persisted state
+            const persisted = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+            expect(persisted.openDir).toBe("/Users/test/channels");
+
+            // Second call: should use the saved folder
+            dialog.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+            // Reset in-memory cache to prove disk persistence works
+            __resetDialogState();
+            openChannelPackage();
+            await vi.waitFor(() => expect(dialog.showOpenDialog).toHaveBeenCalledTimes(2));
+            const opts = dialog.showOpenDialog.mock.calls[1][1];
+            expect(opts.defaultPath).toBe("/Users/test/channels");
+        });
+
+        it("does not persist state when the dialog is canceled", async () => {
+            dialog.showOpenDialog.mockResolvedValue({ canceled: true, filePaths: [] });
+            openChannelPackage();
+            await vi.waitFor(() => expect(dialog.showOpenDialog).toHaveBeenCalled());
+            expect(fs.existsSync(stateFile)).toBe(false);
+        });
+    });
+
+    describe("saveScreenshot", () => {
+        it("passes no defaultPath when no state file exists", async () => {
+            dialog.showSaveDialog.mockResolvedValue({ canceled: true, filePath: "" });
+            saveScreenshot();
+            await vi.waitFor(() => expect(dialog.showSaveDialog).toHaveBeenCalled());
+            const opts = dialog.showSaveDialog.mock.calls[0][1];
+            expect(opts.defaultPath).toBeUndefined();
+        });
+
+        it("saves the selected folder and passes it as defaultPath on the next call", async () => {
+            dialog.showSaveDialog.mockResolvedValue({
+                canceled: false,
+                filePath: "/Users/test/screenshots/screen.png",
+            });
+            saveScreenshot();
+            await vi.waitFor(() => expect(fs.existsSync(stateFile)).toBe(true));
+
+            const persisted = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+            expect(persisted.saveDir).toBe("/Users/test/screenshots");
+
+            // Second call
+            dialog.showSaveDialog.mockResolvedValue({ canceled: true, filePath: "" });
+            __resetDialogState();
+            saveScreenshot();
+            await vi.waitFor(() => expect(dialog.showSaveDialog).toHaveBeenCalledTimes(2));
+            const opts = dialog.showSaveDialog.mock.calls[1][1];
+            expect(opts.defaultPath).toBe("/Users/test/screenshots");
+        });
+
+        it("sends the filePath to the renderer via IPC", async () => {
+            dialog.showSaveDialog.mockResolvedValue({
+                canceled: false,
+                filePath: "/Users/test/screenshots/screen.png",
+            });
+            saveScreenshot();
+            await vi.waitFor(() =>
+                expect(fakeWindow.webContents.send).toHaveBeenCalledWith(
+                    "saveScreenshot",
+                    "/Users/test/screenshots/screen.png"
+                )
+            );
+        });
+    });
+
+    describe("open and save use independent state", () => {
+        it("tracks openDir and saveDir separately", async () => {
+            // Open selects from one folder
+            dialog.showOpenDialog.mockResolvedValue({
+                canceled: false,
+                filePaths: ["/Users/test/apps/channel.zip"],
+            });
+            openChannelPackage();
+            await vi.waitFor(() => expect(fs.existsSync(stateFile)).toBe(true));
+
+            // Save selects from a different folder
+            dialog.showSaveDialog.mockResolvedValue({
+                canceled: false,
+                filePath: "/Users/test/pics/shot.png",
+            });
+            saveScreenshot();
+            await vi.waitFor(() => {
+                const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+                expect(state.saveDir).toBeDefined();
+            });
+
+            const state = JSON.parse(fs.readFileSync(stateFile, "utf8"));
+            expect(state.openDir).toBe("/Users/test/apps");
+            expect(state.saveDir).toBe("/Users/test/pics");
+        });
+    });
+});


### PR DESCRIPTION
## Problem

Electron 43 no longer automatically remembers the last navigated folder in `showOpenDialog` / `showSaveDialog`, so both the **Open Channel Package** and **Save Screenshot** dialogs always start in the same default location instead of where the user last picked a file.

## Solution

Added explicit `defaultPath` tracking per dialog type, persisted to a `dialog-state.json` file in `userData`.

### Changes

- **`src/constants.js`** — Added `DIALOG_STATE_FILE` constant (`"dialog-state.json"`)
- **`src/helpers/dialog.js`** — Core change:
  - Added `loadState()` / `saveState()` helpers using the existing `readJsonFile` / `writeJsonFile` utilities
  - `openChannelPackage()` now passes `state.openDir` as `defaultPath` and records the directory of the selected file
  - `saveScreenshot()` does the same with `state.saveDir`
  - Open and save track **independent** directories
- **`test/unit/helpers/dialog.spec.js`** — 7 new unit tests covering:
  - No `defaultPath` on first use
  - Persisted folder restored on next call (with cache reset to prove disk round-trip)
  - Canceled dialogs don't write state
  - Open/save directories tracked independently
  - IPC send for screenshot path

### Testing

All 749 tests pass (including the 7 new ones).