### PR TITLE
fix: preserve Copy Screenshot enabled state across menu rebuilds

### DIFF
--- a/src/menu/menuService.js
+++ b/src/menu/menuService.js
@@ -256,7 +256,25 @@ function rebuildMenu(template = false) {
         findItem("zip-empty").visible = recentFiles.zip.length === 0;
         findItem("file-clear").enabled = recentFiles.zip.length > 0;
         updatePeerRokuMenuLabels();
+        // Capture enabled states that the Renderer controls dynamically before the
+        // template rebuild resets them to their default (false).
+        const enabledIds = ["copy-screen", "save-screen", "close-channel"];
+        const savedEnabled = {};
+        if (appMenu) {
+            for (const id of enabledIds) {
+                const item = appMenu.getMenuItemById(id);
+                if (item) {
+                    savedEnabled[id] = item.enabled;
+                }
+            }
+        }
         Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate));
+        // Restore the enabled states on the freshly built menu.
+        for (const id of enabledIds) {
+            if (id in savedEnabled) {
+                enableMenuItem(id, savedEnabled[id]);
+            }
+        }
         if (isMacOS && window) {
             if (appMenu.getMenuItemById("view-menu")) {
                 let userTheme = globalThis.sharedObject.theme;

--- a/test/unit/menu/menuService-rebuild.spec.js
+++ b/test/unit/menu/menuService-rebuild.spec.js
@@ -121,12 +121,16 @@ describe("rebuildMenu preserves enabled states on macOS", () => {
             expect(electron.app.applicationMenu.getMenuItemById(id).enabled).toBe(true);
 
             // Trigger a rebuild the way addRecentPackage does.
-            electron.ipcMain.emit("addRecentPackage", {}, {
-                id: "test",
-                path: "/tmp/test.zip",
-                title: "Test",
-                version: "1.0.0",
-            });
+            electron.ipcMain.emit(
+                "addRecentPackage",
+                {},
+                {
+                    id: "test",
+                    path: "/tmp/test.zip",
+                    title: "Test",
+                    version: "1.0.0",
+                }
+            );
 
             // The item must still be enabled after the rebuild.
             expect(electron.app.applicationMenu.getMenuItemById(id).enabled).toBe(true);
@@ -140,12 +144,16 @@ describe("rebuildMenu preserves enabled states on macOS", () => {
         }
 
         // Trigger a rebuild.
-        electron.ipcMain.emit("addRecentPackage", {}, {
-            id: "test",
-            path: "/tmp/test.zip",
-            title: "Test",
-            version: "1.0.0",
-        });
+        electron.ipcMain.emit(
+            "addRecentPackage",
+            {},
+            {
+                id: "test",
+                path: "/tmp/test.zip",
+                title: "Test",
+                version: "1.0.0",
+            }
+        );
 
         // Items must still be disabled.
         for (const id of ["copy-screen", "save-screen", "close-channel"]) {

--- a/test/unit/menu/menuService-rebuild.spec.js
+++ b/test/unit/menu/menuService-rebuild.spec.js
@@ -80,3 +80,76 @@ describe("rebuildMenu with the system theme on macOS", () => {
         expect(win.sentOn("refreshMenu")).toHaveLength(1);
     });
 });
+
+/**
+ * Regression guard: rebuildMenu() reconstructs the entire application menu from templates,
+ * which resets dynamically-enabled items (copy-screen, save-screen, close-channel) to their
+ * template default of false. When a non-.brs app loads, the Renderer sends addRecentPackage
+ * (triggering a rebuild) followed by enableMenuItem calls. On macOS all three messages
+ * arrive in order, but the rebuild was clobbering states that had been set before it.
+ */
+describe("rebuildMenu preserves enabled states on macOS", () => {
+    let platform;
+    let menuService;
+    let settings;
+    let electron;
+
+    beforeEach(async () => {
+        platform = Object.getOwnPropertyDescriptor(process, "platform");
+        Object.defineProperty(process, "platform", { value: "darwin", configurable: true });
+
+        vi.resetModules();
+        electron = await import("../../mocks/electron.js");
+        settings = await import("../../../src/helpers/settings");
+        menuService = await import("../../../src/menu/menuService");
+
+        const win = electron.__registerWindow(electron.createFakeWindow(1));
+        settings.getSettings(win);
+        menuService.createMenu();
+    });
+
+    afterEach(() => {
+        Object.defineProperty(process, "platform", platform);
+        vi.resetModules();
+    });
+
+    it.each(["copy-screen", "save-screen", "close-channel"])(
+        "preserves the enabled state of %s across a rebuild",
+        (id) => {
+            // Simulate the Renderer enabling the item (app is running).
+            menuService.enableMenuItem(id, true);
+            expect(electron.app.applicationMenu.getMenuItemById(id).enabled).toBe(true);
+
+            // Trigger a rebuild the way addRecentPackage does.
+            electron.ipcMain.emit("addRecentPackage", {}, {
+                id: "test",
+                path: "/tmp/test.zip",
+                title: "Test",
+                version: "1.0.0",
+            });
+
+            // The item must still be enabled after the rebuild.
+            expect(electron.app.applicationMenu.getMenuItemById(id).enabled).toBe(true);
+        }
+    );
+
+    it("does not enable items that were disabled before the rebuild", () => {
+        // Ensure all three are disabled (the template default).
+        for (const id of ["copy-screen", "save-screen", "close-channel"]) {
+            expect(electron.app.applicationMenu.getMenuItemById(id).enabled).toBe(false);
+        }
+
+        // Trigger a rebuild.
+        electron.ipcMain.emit("addRecentPackage", {}, {
+            id: "test",
+            path: "/tmp/test.zip",
+            title: "Test",
+            version: "1.0.0",
+        });
+
+        // Items must still be disabled.
+        for (const id of ["copy-screen", "save-screen", "close-channel"]) {
+            expect(electron.app.applicationMenu.getMenuItemById(id).enabled).toBe(false);
+        }
+    });
+});


### PR DESCRIPTION
## Problem

The **Copy Screenshot** menu option was intermittently disabled while an app was running.

## Root Cause

`rebuildMenu()` on macOS calls `Menu.setApplicationMenu(Menu.buildFromTemplate(menuTemplate))`, which reconstructs the entire application menu from templates. The templates define `copy-screen`, `save-screen`, and `close-channel` with `enabled: false` as their default.

The function already preserved **checked** states (theme, locale, display modes, etc.) after rebuilding, but never preserved **enabled** states. When an app loads, `appLoaded()` sends `addRecentPackage` (triggering a rebuild) which could clobber the enabled state, leaving the menu items disabled despite an app actively running.

## Fix

Before the `Menu.buildFromTemplate()` call, capture the enabled states of the three Renderer-controlled items (`copy-screen`, `save-screen`, `close-channel`) from the old menu, then restore them on the freshly built menu — following the same save/restore pattern already used for checked states.

## Changes

- **`src/menu/menuService.js`** — Save and restore enabled states in `rebuildMenu()`
- **`test/unit/menu/menuService-rebuild.spec.js`** — 4 new regression tests verifying enabled states survive a rebuild in both directions

## Testing

- All 753 tests pass
- Manually verified with `yarn start`: Copy Screenshot stays enabled while an app is running, including after recent-file list updates